### PR TITLE
Add rule to detect non-remembered mutable/derivedStateOf

### DIFF
--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
@@ -1,0 +1,58 @@
+package com.twitter.rules.ktlint.compose
+
+import com.twitter.rules.core.findChildrenByClass
+import com.twitter.rules.core.isComposable
+import com.twitter.rules.core.ktlint.Emitter
+import com.twitter.rules.core.ktlint.TwitterKtRule
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+class ComposeRememberMissingCheck : TwitterKtRule("compose-remember-missing-check") {
+
+    override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        if (!function.isComposable) return
+
+        // To keep memory consumption in check, we first traverse down until we see one of our known functions
+        // that need remembering
+        function.findChildrenByClass<KtCallExpression>()
+            .filter { MethodsThatNeedRemembering.contains(it.calleeExpression?.text) }
+            // Only for those, we traverse up to [function], to see if it was actually remembered
+            .filterNot { it.isRemembered(function) }
+            // If it wasn't, we show the error
+            .forEach { callExpression ->
+                when (callExpression.calleeExpression!!.text) {
+                    "mutableStateOf" -> emitter.report(callExpression.startOffset, MutableStateOfNotRemembered, false)
+                    "derivedStateOf" -> emitter.report(callExpression.startOffset, DerivedStateOfNotRemembered, false)
+                }
+            }
+    }
+
+    private fun KtCallExpression.isRemembered(stopAt: PsiElement): Boolean {
+        var current: PsiElement = parent
+        while (current != stopAt) {
+            (current as? KtCallExpression)?.let { callExpression ->
+                if (callExpression.calleeExpression?.text?.startsWith("remember") == true) return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    companion object {
+        private val MethodsThatNeedRemembering = setOf(
+            "derivedStateOf",
+            "mutableStateOf"
+        )
+        val DerivedStateOfNotRemembered = errorMessage("derivedStateOf")
+        val MutableStateOfNotRemembered = errorMessage("mutableStateOf")
+
+        private fun errorMessage(name: String): String = """
+            Using `$name` in a @Composable function without it being inside of a remember function.
+            If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+            See LINK TBD s for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.RuleSetProvider
 class TwitterComposeRuleSetProvider : RuleSetProvider {
     override fun get(): RuleSet = RuleSet(
         "twitter-compose",
-        ComposeNamingCheck()
+        ComposeNamingCheck(),
+        ComposeRememberMissingCheck(),
     )
 }

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
@@ -1,0 +1,151 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeRememberMissingCheckTest {
+
+    private val rule = ComposeRememberMissingCheck()
+
+    @Test
+    fun `passes when a non-remembered mutableStateOf is used outside of a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                val msof = mutableStateOf("X")
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `errors when a non-remembered mutableStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = mutableStateOf("X")
+                }
+                @Composable
+                fun MyComposable(something: State<String> = mutableStateOf("X")) {
+                }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 3,
+                col = 21,
+                ruleId = "compose-remember-missing-check",
+                detail = ComposeRememberMissingCheck.MutableStateOfNotRemembered,
+                canBeAutoCorrected = false
+            ),
+            LintError(
+                line = 6,
+                col = 45,
+                ruleId = "compose-remember-missing-check",
+                detail = ComposeRememberMissingCheck.MutableStateOfNotRemembered,
+                canBeAutoCorrected = false
+            ),
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @Test
+    fun `passes when a remembered mutableStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = remember { mutableStateOf("X") }
+                ) {
+                    val something = remember { mutableStateOf("X") }
+                    val something2 by remember { mutableStateOf("Y") }
+                }
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a rememberSaveable mutableStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = rememberSaveable { mutableStateOf("X") }
+                ) {
+                    val something = rememberSaveable { mutableStateOf("X") }
+                    val something2 by rememberSaveable { mutableStateOf("Y") }
+                }
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a non-remembered derivedStateOf is used outside of a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                val dsof = derivedStateOf("X")
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `errors when a non-remembered derivedStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = derivedStateOf { "X" }
+                }
+                @Composable
+                fun MyComposable(something: State<String> = derivedStateOf { "X" }) {
+                }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 3,
+                col = 21,
+                ruleId = "compose-remember-missing-check",
+                detail = ComposeRememberMissingCheck.DerivedStateOfNotRemembered,
+                canBeAutoCorrected = false
+            ),
+            LintError(
+                line = 6,
+                col = 45,
+                ruleId = "compose-remember-missing-check",
+                detail = ComposeRememberMissingCheck.DerivedStateOfNotRemembered,
+                canBeAutoCorrected = false
+            ),
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @Test
+    fun `passes when a remembered derivedStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = remember { derivedStateOf { "X" } }
+                ) {
+                    val something = remember { derivedStateOf { "X" } }
+                    val something2 by remember { derivedStateOf { "Y" } }
+                }
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+}


### PR DESCRIPTION
When used in a Composable, `mutableStateOf` and `derivedStateOf` should be remembered. It is easy to forget about this, and the consecuences are annoying to deal with. So here we are.