### PR TITLE
Add rule to detect multiple content emissions in a composable

### DIFF
--- a/core/common/src/main/kotlin/com/twitter/rules/core/KtFunctions.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/KtFunctions.kt
@@ -7,6 +7,9 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 val KtFunction.returnsValue: Boolean
     get() = typeReference != null && typeReference!!.text != "Unit"
 
+val KtFunction.hasReceiverType: Boolean
+    get() = receiverTypeReference != null
+
 val KtFunction.isPrivate: Boolean
     get() = visibilityModifierType() == KtTokens.PRIVATE_KEYWORD
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -96,7 +96,7 @@ private fun ColumnScope.InnerContent() {
 ```
 This effectively ties the function to be called from a Column, but is still not recommended (although permitted).
 
-Related rule: TBD
+Related rule: [compose-multiple-emitters-check](https://github.com/twitter/compose-ktlint-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt)
 
 ### Naming @Composable functions properly
 

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
@@ -1,48 +1,118 @@
 package com.twitter.rules.ktlint.compose
 
+import com.twitter.rules.core.emitsContent
+import com.twitter.rules.core.findChildrenByClass
+import com.twitter.rules.core.hasReceiverType
 import com.twitter.rules.core.isComposable
 import com.twitter.rules.core.ktlint.Emitter
 import com.twitter.rules.core.ktlint.TwitterKtRule
 import com.twitter.rules.core.ktlint.report
 import com.twitter.rules.core.returnsValue
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 
-class ComposeNamingCheck : TwitterKtRule("compose-naming-check") {
+class ComposeMultipleContentEmittersCheck : TwitterKtRule("compose-multiple-emitters-check") {
 
-    override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
-        if (!function.isComposable) return
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+        // CHECK #1 : We want to find the composables first that are at risk of emitting content from multiple sources.
+        val composables = file.findChildrenByClass<KtFunction>()
+            .filter { it.isComposable }
+            // We don't want to analyze composables that are extension functions, as they might be things like
+            // BoxScope which are legit and we want to avoid false positives.
+            .filter { it.hasBlockBody() }
+            // We want only methods with a body
+            .filterNot { it.hasReceiverType }
 
-        // If it's a block we can't know if there is a return type or not from ktlint
-        if (!function.hasBlockBody()) return
-        val firstLetter = function.name?.first() ?: return
+        // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
+        val composableToEmissionCount = composables.associateWith { it.directUiEmitterCount }
 
-        if (function.returnsValue) {
-            // If it returns value, the composable should start with a lowercase letter
-            if (firstLetter.isUpperCase()) {
-                emitter.report(function, ComposablesThatReturnResultsShouldBeLowercase)
+        // We can start showing errors, for composables that emit more than once (from the list of known composables)
+        val directEmissionsReported = composableToEmissionCount.filterValues { it > 1 }.keys
+        directEmissionsReported.forEach { composable ->
+            emitter.report(composable, MultipleContentEmittersDetected)
+        }
+
+        // Now we can give some extra passes through the list of composables, and try to get a more accurate count.
+        // We want to make sure that if these composables are using other composables in this file that emit UI,
+        // those are taken into account too. For example:
+        // @Composable fun Comp1() { Text("Hi") }
+        // @Composable fun Comp2() { Text("Hola") }
+        // @Composable fun Comp3() { Comp1() Comp2() } // This wouldn't be picked up at first, but should after 1 loop
+        var currentMapping = composableToEmissionCount
+
+        var shouldMakeAnotherPass = true
+        while (shouldMakeAnotherPass) {
+            val updatedMapping = currentMapping.mapValues { (functionNode, _) ->
+                functionNode.indirectUiEmitterCount(currentMapping)
             }
-        } else {
-            // If it returns Unit or doesn't have a return type, we should start with an uppercase letter
-            if (firstLetter.isLowerCase()) {
-                emitter.report(function, ComposablesThatDoNotReturnResultsShouldBeCapitalized)
+            when {
+                updatedMapping != currentMapping -> currentMapping = updatedMapping
+                else -> shouldMakeAnotherPass = false
             }
         }
+
+        // Here we have the settled data after all the needed passes, so we want to show errors for them,
+        // if they were not caught already by the 1st emission loop
+        val indirectEmissionsReported = currentMapping
+            .filterValues { it > 1 }
+            .filterNot { directEmissionsReported.contains(it.key) }
+            .keys
+
+        indirectEmissionsReported.forEach { composable ->
+            emitter.report(composable, MultipleContentEmittersDetected)
+        }
+
+        // CHECK #2: Composables that emit UI should not return any value
+
+        // Data in currentMapping should have all the # of emissions inferred for each composable in this file,
+        // so we want to iterate through all of them
+        currentMapping.filterValues { it > 0 }.keys
+            // If the function doesn't have a return type or returns Unit explicitly, it's valid. Otherwise, show error.
+            .filter { it.returnsValue }
+            // In here we will have functions that emit UI and return a type other than Unit, which is no bueno.
+            .forEach { composable ->
+                emitter.report(composable, ContentEmitterReturningValuesToo)
+            }
+    }
+
+    private val KtFunction.directUiEmitterCount: Int
+        get() = bodyBlockExpression?.let { block ->
+            block.statements
+                .filterIsInstance<KtCallExpression>()
+                .count { it.emitsContent }
+        } ?: 0
+
+    private fun KtFunction.indirectUiEmitterCount(mapping: Map<KtFunction, Int>): Int {
+        val bodyBlock = bodyBlockExpression ?: return 0
+        return bodyBlock.statements
+            .filterIsInstance<KtCallExpression>()
+            .count { callExpression ->
+                // If it's a direct hit on our list, it should count directly
+                if (callExpression.emitsContent) return@count true
+
+                val name = callExpression.calleeExpression?.text ?: return@count false
+                // If the hit is in the provided mapping, it means it is using a composable that we know emits UI,
+                // that we inferred from previous passes
+                val value = mapping.mapKeys { entry -> entry.key.name }.getOrElse(name) { return@count false }
+                value > 0
+            }
     }
 
     companion object {
 
-        val ComposablesThatDoNotReturnResultsShouldBeCapitalized = """
-            Composable functions that return Unit should start with an uppercase letter.
-            They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
+        val MultipleContentEmittersDetected = """
+            Composable functions should only be emitting content into the composition from one source at their top level.
 
-            For more information: https://github.com/twitter/compose-ktlint-rules/blob/main/docs/rules.md#naming-composable-functions-properly
+            See https://github.com/twitter/compose-ktlint-rules/blob/main/docs/rules.md#do-not-emit-multiple-pieces-of-content for more information.
         """.trimIndent()
 
-        val ComposablesThatReturnResultsShouldBeLowercase = """
-            Composable functions that return a value should start with a lowercase letter.
-            While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
+        val ContentEmitterReturningValuesToo = """
+            Composable functions should either emit content into the composition or return a value, but not both.
+            If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks
+            should be provided as parameters to the composable function by the caller.
 
-            For more information: https://github.com/twitter/compose-ktlint-rules/blob/main/docs/rules.md#naming-composable-functions-properly
+            See https://github.com/twitter/compose-ktlint-rules/blob/main/docs/rules.md#do-not-emit-multiple-pieces-of-content for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -8,6 +8,7 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
         "twitter-compose",
         ComposeModifierMissingCheck(),
         ComposeModifierUsedOnceCheck(),
+        ComposeMultipleContentEmittersCheck(),
         ComposeMutableParametersCheck(),
         ComposeNamingCheck(),
         ComposeRememberMissingCheck(),

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
@@ -6,71 +6,80 @@ import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
-class ComposeNamingCheckTest {
+class ComposeMultipleContentEmittersCheckTest {
 
-    private val rule = ComposeNamingCheck()
+    private val rule = ComposeMultipleContentEmittersCheck()
 
     @Test
-    fun `passes when a composable that returns values is lowercase`() {
+    fun `passes when only one item emits up at the top level`() {
         @Language("kotlin")
         val errors = rule.lint(
             """
                 @Composable
-                fun myComposable(): Something { }
+                fun Something() {
+                    val something = rememberWhatever()
+                    Column {
+                        Text("Hi")
+                        Text("Hola")
+                    }
+                    LaunchedEffect(Unit) {
+                    }
+                }
             """.trimIndent()
         )
         assertThat(errors).isEmpty()
     }
 
     @Test
-    fun `passes when a composable that returns nothing or Unit is uppercase`() {
+    fun `passes when the composable is an extension function`() {
         @Language("kotlin")
         val errors = rule.lint(
             """
                 @Composable
-                fun MyComposable() { }
+                fun ColumnScope.Something() {
+                    Text("Hi")
+                    Text("Hola")
+                }
                 @Composable
-                fun MyComposable(): Unit { }
+                fun RowScope.Something() {
+                    Spacer16()
+                    Text("Hola")
+                }
             """.trimIndent()
         )
         assertThat(errors).isEmpty()
     }
 
     @Test
-    fun `passes when a composable doesn't have a body block, is a property or a lambda`() {
+    fun `errors when a Composable function has more than one UI emitter at the top level`() {
         @Language("kotlin")
         val errors = rule.lint(
             """
                 @Composable
-                fun MyComposable() = Text("bleh")
-
-                val composable: Something
-                    @Composable get() { }
-
-                val composable: Something
-                    @Composable get() = OtherComposable()
-
-                val whatever = @Composable { }
-            """.trimIndent()
-        )
-        assertThat(errors).isEmpty()
-    }
-
-    @Test
-    fun `errors when a composable returns a value and is capitalized`() {
-        @Language("kotlin")
-        val errors = rule.lint(
-            """
+                fun Something() {
+                    Text("Hi")
+                    Text("Hola")
+                }
                 @Composable
-                fun MyComposable(): Something { }
+                fun Something() {
+                    Spacer16()
+                    Text("Hola")
+                }
             """.trimIndent()
         )
         val expectedErrors = listOf(
             LintError(
                 line = 2,
                 col = 5,
-                ruleId = "compose-naming-check",
-                detail = ComposeNamingCheck.ComposablesThatReturnResultsShouldBeLowercase,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected,
+                canBeAutoCorrected = false
+            ),
+            LintError(
+                line = 7,
+                col = 5,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected,
                 canBeAutoCorrected = false
             ),
         )
@@ -78,30 +87,116 @@ class ComposeNamingCheckTest {
     }
 
     @Test
-    fun `errors when a composable returns nothing or Unit and is lowercase`() {
+    fun `errors when a Composable function has more than one indirect UI emitter at the top level`() {
         @Language("kotlin")
         val errors = rule.lint(
             """
                 @Composable
-                fun myComposable() { }
-
+                fun Something1() {
+                    Something2()
+                }
                 @Composable
-                fun myComposable(): Unit { }
+                fun Something2() {
+                    Text("Hola")
+                    Something3()
+                }
+                @Composable
+                fun Something3() {
+                    Text("Hi")
+                }
+                @Composable
+                fun Something4() {
+                    Text("Alo")
+                }
+                @Composable
+                fun Something5() {
+                    Something3()
+                    Something4()
+                }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 6,
+                col = 5,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected,
+                canBeAutoCorrected = false
+            ),
+            LintError(
+                line = 19,
+                col = 5,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected,
+                canBeAutoCorrected = false
+            ),
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @Test
+    fun `make sure to not report twice the same composable`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun Something() {
+                    Text("Hi")
+                    Text("Hola")
+                    Something2()
+                }
+                @Composable
+                fun Something2() {
+                    Text("Alo")
+                }
             """.trimIndent()
         )
         val expectedErrors = listOf(
             LintError(
                 line = 2,
                 col = 5,
-                ruleId = "compose-naming-check",
-                detail = ComposeNamingCheck.ComposablesThatDoNotReturnResultsShouldBeCapitalized,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected,
+                canBeAutoCorrected = false
+            ),
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @Test
+    fun `error out when detecting a content emitting composable that returns something other than unit`() {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+                @Composable
+                fun Something(): String { // This one emits content directly and should fail
+                    Text("Hi")
+                    return "Potato"
+                }
+                @Composable
+                fun Something2(): WhateverState { // This one emits content indirectly and should fail too
+                    Something3()
+                    return remember { WhateverState() }
+                }
+                @Composable
+                fun Something3() { // This one is fine but calling it should make Something2 fail
+                    HorizonIcon(icon = HorizonIcon.Arrow)
+                }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 2,
+                col = 5,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo,
                 canBeAutoCorrected = false
             ),
             LintError(
-                line = 5,
+                line = 7,
                 col = 5,
-                ruleId = "compose-naming-check",
-                detail = ComposeNamingCheck.ComposablesThatDoNotReturnResultsShouldBeCapitalized,
+                ruleId = "compose-multiple-emitters-check",
+                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo,
                 canBeAutoCorrected = false
             ),
         )


### PR DESCRIPTION
Composables that emit content from multiple composables at its top level are problematic: we don't know how they will be rendered.

For example:
```kotlin
@Composable
private fun InnerContent() {
    Text(...)
    Image(...)
    Button(...)
}
```

If this InnerContent composable was wrapped in a `Column`, it will stack them vertically, but if it were wrapped in a `Row`, it will show them horizontally. Instead, InnerContent should be cohesive and emit a single layout node itself.