### PR TITLE
Add ViewModel injection check

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -50,7 +50,7 @@ If a composable should offer additional control surfaces to its caller, those co
 
 More info: [Compose API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#emit-xor-return-a-value)
 
-Related rule: TBD
+Related rule: [compose-multiple-emitters-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt)
 
 ### Do not emit multiple pieces of content
 
@@ -137,7 +137,7 @@ private fun MyComposable(
 
 ```
 
-Related rule: TBD
+Related rule: [compose-vm-injection-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt)
 
 ## Modifiers
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.6.21"
 ktlint = "0.45.2"
+junit = "5.8.2"
 
 [libraries]
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
@@ -13,5 +14,6 @@ kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", 
 
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.20.0"
 
-junit5 = "org.junit.jupiter:junit-jupiter:5.8.2"
+junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 assertj = "org.assertj:assertj-core:3.22.0"

--- a/rules/ktlint/build.gradle
+++ b/rules/ktlint/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation libs.ktlint.test
     testImplementation libs.junit5
+    testImplementation libs.junit5.params
     testImplementation libs.assertj
 }
 

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
@@ -1,0 +1,120 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.core.ast.firstChildLeafOrSelf
+import com.pinterest.ktlint.core.ast.lastChildLeafOrSelf
+import com.pinterest.ktlint.core.ast.nextCodeSibling
+import com.twitter.rules.core.definedInInterface
+import com.twitter.rules.core.findChildrenByClass
+import com.twitter.rules.core.findDirectChildrenByClass
+import com.twitter.rules.core.findDirectFirstChildByClass
+import com.twitter.rules.core.isComposable
+import com.twitter.rules.core.isOverride
+import com.twitter.rules.core.ktlint.Emitter
+import com.twitter.rules.core.ktlint.TwitterKtRule
+import com.twitter.rules.core.ktlint.report
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.ElementType
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+class ComposeViewModelInjectionCheck : TwitterKtRule("compose-vm-injection-check") {
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+        file.findChildrenByClass<KtFunction>()
+            .filter { it.isComposable && !it.isOverride && !it.definedInInterface }
+            .forEach { visitComposable(it, autoCorrect, emitter) }
+    }
+
+    private fun visitComposable(composable: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        val bodyBlock = composable.bodyBlockExpression ?: return
+
+        bodyBlock.findChildrenByClass<KtProperty>()
+            .flatMap { property ->
+                property.findDirectChildrenByClass<KtCallExpression>()
+                    .filter { KnownViewModelFactories.contains(it.calleeExpression?.text) }
+                    .map { property to it.calleeExpression!!.text }
+            }
+            .forEach { (property, viewModelFactoryName) ->
+                emitter.report(property, errorMessage(viewModelFactoryName), true)
+                if (autoCorrect) {
+                    fix(composable, property, viewModelFactoryName)
+                }
+            }
+    }
+
+    private fun fix(composable: KtFunction, property: KtProperty, viewModelFactoryName: String) {
+        // First of all, we want to extract the property name and all the arguments
+        val variableName = property.name
+        val callExpression = property.findDirectFirstChildByClass<KtCallExpression>() ?: return
+        val argumentList = callExpression.valueArgumentList ?: return
+
+        // We also want the ViewModel type, with two possibilities to support:
+        // val viewModel : VM = viewModel(...)
+        // val viewModel = viewModel<VM>(...)
+        val viewModelTypeReference = property.typeReference
+            ?: property.findDirectFirstChildByClass<KtCallExpression>()?.typeArguments?.singleOrNull()
+            ?: return
+
+        // Then we need to check the parameters on the FunctionNode. We want to be the last element added
+        // EXCEPT in the case in which there is a function as the last parameter, in which case we want to be
+        // second to last
+        val rawViewModelType = viewModelTypeReference.text
+        val rawArgumentList = argumentList.text
+        val lastParameters = composable.valueParameters.takeLast(2)
+        val parameterList = composable.valueParameterList ?: return
+
+        // Generate the VALUE_PARAMETER for variableName: VMType = viewModel(...)
+        val newCode = "$variableName: $rawViewModelType = $viewModelFactoryName$rawArgumentList"
+        val factory = KtPsiFactory(parameterList)
+        val newParam = factory.createParameter(newCode)
+
+        when {
+            // If there are no parameters, we will insert the code directly
+            lastParameters.isEmpty() -> parameterList.addParameter(newParam)
+            // If the last element is a function, we need to preserve the trailing lambda, so we will insert
+            // the code before that last param
+            lastParameters.last().typeReference?.typeElement is KtFunctionType -> {
+                // If there's only 1 param, we insert the code with the initial parenthesis
+                if (lastParameters.size == 1) {
+                    val firstToken = parameterList.node.firstChildLeafOrSelf() as LeafPsiElement
+                    firstToken.rawReplaceWithText("($newCode, ")
+                } else {
+                    // If there were 2+ params, we insert the code between the two parameters
+                    val lastToken = lastParameters.first()
+                        .node
+                        .nextCodeSibling()!!
+                        .lastChildLeafOrSelf() as LeafPsiElement
+                    // Last token here would be the previous comma, if there were spaces between the comma
+                    // and the functional type (the next sibling), we would insert ourselves at the left of it.
+                    lastToken.rawReplaceWithText("${lastToken.text} $newCode,")
+                }
+            }
+            else -> {
+                parameterList.addParameter(newParam)
+            }
+        }
+
+        // And finally, we can delete the original property from the code
+        // 1. If there's whitespace before (code indent spaces) we remove them
+        property.node.treePrev?.takeIf { it.elementType == ElementType.WHITE_SPACE }?.psi?.delete()
+        // 2. Remove the actual code
+        property.delete()
+    }
+
+    companion object {
+
+        val KnownViewModelFactories by lazy { setOf("viewModel", "weaverViewModel") }
+
+        fun errorMessage(factoryName: String) = """
+            Implicit dependencies of composables should be made explicit.
+
+            Usages of $factoryName to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
+
+            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#make-dependencies-explicit for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
@@ -1,0 +1,224 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.format
+import com.pinterest.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class ComposeViewModelInjectionCheckTest {
+
+    private val rule = ComposeViewModelInjectionCheck()
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `passes when a weaverViewModel is used as a default param`(viewModel: String) {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+            @Composable
+            fun MyComposable(
+                modifier: Modifier,
+                viewModel: MyVM = $viewModel(),
+                viewModel2: MyVM = $viewModel(),
+            ) { }
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `overridden functions are ignored`(viewModel: String) {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+            @Composable
+            override fun Content() {
+                val viewModel = $viewModel<MyVM>()
+            }
+            """.trimIndent()
+        )
+        assertThat(errors).isEmpty()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+            @Composable
+            fun MyComposable(modifier: Modifier) {
+                val viewModel = $viewModel<MyVM>()
+            }
+            @Composable
+            fun MyComposableNoParams() {
+                val viewModel: MyVM = $viewModel()
+            }
+            @Composable
+            fun MyComposableTrailingLambda(block: () -> Unit) {
+                val viewModel: MyVM = $viewModel()
+            }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 3,
+                col = 9,
+                ruleId = "compose-vm-injection-check",
+                detail = ComposeViewModelInjectionCheck.errorMessage(viewModel),
+                canBeAutoCorrected = true
+            ),
+            LintError(
+                line = 7,
+                col = 9,
+                ruleId = "compose-vm-injection-check",
+                detail = ComposeViewModelInjectionCheck.errorMessage(viewModel),
+                canBeAutoCorrected = true
+            ),
+            LintError(
+                line = 11,
+                col = 9,
+                ruleId = "compose-vm-injection-check",
+                detail = ComposeViewModelInjectionCheck.errorMessage(viewModel),
+                canBeAutoCorrected = true
+            )
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
+        @Language("kotlin")
+        val errors = rule.lint(
+            """
+            @Composable
+            fun MyComposable(modifier: Modifier) {
+                if (blah) {
+                    val viewModel = $viewModel<MyVM>()
+                } else {
+                    val viewModel: MyOtherVM = $viewModel()
+                }
+            }
+            """.trimIndent()
+        )
+        val expectedErrors = listOf(
+            LintError(
+                line = 4,
+                col = 13,
+                ruleId = "compose-vm-injection-check",
+                detail = ComposeViewModelInjectionCheck.errorMessage(viewModel),
+                canBeAutoCorrected = true
+            ),
+            LintError(
+                line = 6,
+                col = 13,
+                ruleId = "compose-vm-injection-check",
+                detail = ComposeViewModelInjectionCheck.errorMessage(viewModel),
+                canBeAutoCorrected = true
+            )
+        )
+        assertThat(errors).isEqualTo(expectedErrors)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `fix no args composable function adds the code inside the parentheses`(viewModel: String) {
+        @Language("kotlin")
+        val badCode = """
+            @Composable
+            fun MyComposableNoParams() {
+                val viewModel: MyVM = $viewModel()
+            }
+            @Composable
+            fun MyComposableNoParams() {
+                val viewModel: MyVM = $viewModel(named = "meh")
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expectedCode = """
+            @Composable
+            fun MyComposableNoParams(viewModel: MyVM = $viewModel()) {
+            }
+            @Composable
+            fun MyComposableNoParams(viewModel: MyVM = $viewModel(named = "meh")) {
+            }
+        """.trimIndent()
+        val fixedCode = rule.format(badCode)
+        assertThat(fixedCode).isEqualTo(expectedCode)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `fix normal args composable function adds the new code at the end`(viewModel: String) {
+        @Language("kotlin")
+        val badCode = """
+            @Composable
+            fun MyComposable(modifier: Modifier = Modifier) {
+                val viewModel: MyVM = $viewModel()
+            }
+            @Composable
+            fun MyComposable(modifier: Modifier = Modifier,) {
+                val viewModel: MyVM = $viewModel()
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expectedCode = """
+            @Composable
+            fun MyComposable(modifier: Modifier = Modifier,viewModel: MyVM = $viewModel()) {
+            }
+            @Composable
+            fun MyComposable(modifier: Modifier = Modifier,viewModel: MyVM = $viewModel(),) {
+            }
+        """.trimIndent()
+        val fixedCode = rule.format(badCode)
+        assertThat(fixedCode).isEqualTo(expectedCode)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    fun `fix trailing lambda args composable function adds the new code before the trailing lambda`(viewModel: String) {
+        @Language("kotlin")
+        val badCode = """
+            @Composable
+            fun MyComposableTrailingLambda(block: () -> Unit) {
+                val viewModel: MyVM = $viewModel()
+            }
+            @Composable
+            fun MyComposableTrailingLambda(text: String, block: () -> Unit) {
+                val viewModel: MyVM = $viewModel()
+            }
+            @Composable
+            fun MyComposableTrailingLambda(
+                text: String,
+                block: () -> Unit
+            ) {
+                val viewModel: MyVM = $viewModel()
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expectedCode = """
+            @Composable
+            fun MyComposableTrailingLambda(viewModel: MyVM = $viewModel(), block: () -> Unit) {
+            }
+            @Composable
+            fun MyComposableTrailingLambda(text: String, viewModel: MyVM = $viewModel(), block: () -> Unit) {
+            }
+            @Composable
+            fun MyComposableTrailingLambda(
+                text: String, viewModel: MyVM = $viewModel(),
+                block: () -> Unit
+            ) {
+            }
+        """.trimIndent()
+        val fixedCode = rule.format(badCode)
+        assertThat(fixedCode).isEqualTo(expectedCode)
+    }
+}


### PR DESCRIPTION
Acquiring a ViewModel in the middle of a composable implies making it an implicit dependency. We should aim towards making all those dependencies explicit, so this rule will flag all usages. It also includes an autofix for those particular issues.