### PR TITLE
Add rule to enforce proper parameter ordering in composable functions

### DIFF
--- a/core/common/src/main/kotlin/com/twitter/rules/core/Composables.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/Composables.kt
@@ -124,6 +124,6 @@ val ComposableEmittersListRegex by lazy {
 
 val KtFunction.modifierParameter: KtParameter?
     get() {
-        val modifiers = valueParameters.filter { it.typeReference?.text == "Modifier" }
+        val modifiers = valueParameters.filter { it.isModifier }
         return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
     }

--- a/core/common/src/main/kotlin/com/twitter/rules/core/KotlinUtils.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/KotlinUtils.kt
@@ -1,0 +1,4 @@
+package com.twitter.rules.core
+
+fun <T> T.runIf(value: Boolean, block: T.() -> T): T =
+    if (value) block() else this

--- a/core/common/src/main/kotlin/com/twitter/rules/core/KtParameters.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/KtParameters.kt
@@ -28,3 +28,6 @@ private val KnownMutableCommonTypes by lazy {
         "MutableState<.*>\\??"
     ).map { Regex(it) }
 }
+
+val KtParameter.isModifier: Boolean
+    get() = typeReference?.text == "Modifier"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,6 +108,16 @@ More information: [Naming Unit @Composable functions as entities](https://github
 
 Related rule: [twitter-compose:naming-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheck.kt)
 
+### Ordering @Composable parameters properly
+
+When writing Kotlin, it's a good practice to write the parameters for your methods by putting the mandatory parameters first, followed by the optional ones (aka the ones with default values). By doing so, [we minimize the number times we will need to write the name for arguments explicitly](https://kotlinlang.org/docs/functions.html#default-arguments).
+
+Modifiers occupy the first optional parameter slot to set a consistent expectation for developers that they can always provide a modifier as the final positional parameter to an element call for any given element's common case.
+
+More information: [Kotlin default arguments](https://kotlinlang.org/docs/functions.html#default-arguments) and [Elements accept and respect a Modifier parameter](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#why-8).
+
+Related rule: [twitter-compose:param-order-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt)
+
 ### Make dependencies explicit
 
 When designing our composables, we should always try to be explicit about the dependencies they take in. If you acquire a ViewModel or an instance from DI in the body of the composable, you are making this dependency implicit, which has the downsides of making it hard to test and harder to reuse.

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
@@ -1,0 +1,67 @@
+package com.twitter.rules.ktlint.compose
+
+import com.twitter.rules.core.isComposable
+import com.twitter.rules.core.isModifier
+import com.twitter.rules.core.ktlint.Emitter
+import com.twitter.rules.core.ktlint.TwitterKtRule
+import com.twitter.rules.core.ktlint.report
+import com.twitter.rules.core.runIf
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtParameter
+
+class ComposeParameterOrderCheck : TwitterKtRule("twitter-compose:param-order-check") {
+
+    override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        if (!function.isComposable) return
+
+        // We need to make sure the proper order is respected. It should be:
+        // 1. params without defaults
+        // 2. modifiers
+        // 3. params with defaults
+        // 4. optional: function that might have no default
+
+        // Let's try to build the ideal ordering first, and compare against that.
+        val currentOrder = function.valueParameters
+
+        // We look in the original params without defaults and see if the last one is a function.
+        val hasTrailingFunction = function.hasTrailingFunction
+        val trailingLambda = if (hasTrailingFunction) {
+            listOf(function.valueParameters.last())
+        } else {
+            emptyList()
+        }
+
+        // We extract the params without with and without defaults, and keep the order between them
+        val (withDefaults, withoutDefaults) = function.valueParameters
+            .runIf(hasTrailingFunction) { dropLast(1) }
+            .partition { it.hasDefaultValue() }
+
+        // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
+        // about that case. We will sort the params with defaults so that the modifier(s) go first.
+        val sortedWithDefaults = withDefaults.sortedByDescending { it.isModifier }
+
+        // We create our ideal ordering of params for the ideal composable.
+        val properOrder = withoutDefaults + sortedWithDefaults + trailingLambda
+
+        // If it's not the same as the current order, we show the rule violation.
+        if (currentOrder != properOrder) {
+            emitter.report(function, createErrorMessage(currentOrder, properOrder))
+        }
+    }
+
+    private val KtFunction.hasTrailingFunction: Boolean
+        get() = valueParameters.lastOrNull()?.typeReference?.typeElement is KtFunctionType
+
+    companion object {
+        fun createErrorMessage(currentOrder: List<KtParameter>, properOrder: List<KtParameter>): String =
+            createErrorMessage(currentOrder.joinToString { it.text }, properOrder.joinToString { it.text })
+
+        fun createErrorMessage(currentOrder: String, properOrder: String): String = """
+            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+            Current params are: [$currentOrder] but should be [$properOrder].
+
+            For more information: https://github.com/twitter/compose-rules/blob/main/docs/rules.md#ordering-composable-parameters-properly
+        """.trimIndent()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -11,6 +11,7 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
         ComposeMultipleContentEmittersCheck(),
         ComposeMutableParametersCheck(),
         ComposeNamingCheck(),
+        ComposeParameterOrderCheck(),
         ComposeRememberMissingCheck(),
         ComposeViewModelForwardingCheck(),
     )


### PR DESCRIPTION
Parameters should be ordered by putting the mandatory ones first, followed by the optional ones (aka the ones with a default). When a Modifier is part of those arguments, it should have a default `Modifier` value, and be the first one of the optional values.