### PR TITLE
Separate modifier rules and update ordering checks

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -114,7 +114,7 @@ When writing Kotlin, it's a good practice to write the parameters for your metho
 
 Modifiers occupy the first optional parameter slot to set a consistent expectation for developers that they can always provide a modifier as the final positional parameter to an element call for any given element's common case.
 
-More information: [Kotlin default arguments](https://kotlinlang.org/docs/functions.html#default-arguments) and [Elements accept and respect a Modifier parameter](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#why-8).
+More information: [Kotlin default arguments](https://kotlinlang.org/docs/functions.html#default-arguments), [Modifier docs](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier) and [Elements accept and respect a Modifier parameter](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#why-8).
 
 Related rule: [twitter-compose:param-order-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt)
 
@@ -159,7 +159,7 @@ They are especially important for your public components, as they allow callers 
 
 More info: [Always provide a Modifier parameter](https://chris.banes.dev/always-provide-a-modifier/)
 
-Related rule: [twitter-compose:modifier-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt)
+Related rule: [twitter-compose:modifier-missing-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt)
 
 ### Don't re-use modifiers
 
@@ -190,4 +190,12 @@ private fun InnerContent(modifier: Modifier = Modifier) {
 }
 ```
 
-Related rule: [twitter-compose:modifier-used-once-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierUsedOnceCheck.kt)
+Related rule: [twitter-compose:modifier-reused-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt)
+
+### Modifiers should have default parameters
+
+Composables that accept a Modifier as a parameter to be applied to the whole component represented by the composable function should name the parameter modifier and assign the parameter a default value of `Modifier`. It should appear as the first optional parameter in the parameter list; after all required parameters (except for trailing lambda parameters) but before any other parameters with default values. Any default modifiers desired by a composable function should come after the modifier parameter's value in the composable function's implementation, keeping Modifier as the default parameter value.
+
+Mode info: [Modifier documentation](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier)
+
+Related rule: [twitter-compose:modifier-without-default-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt)

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
@@ -1,6 +1,5 @@
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.core.ast.lastChildLeafOrSelf
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.ktlint.TwitterKtlintRule
 import com.twitter.rules.core.report
@@ -9,11 +8,10 @@ import com.twitter.rules.core.util.emitsContent
 import com.twitter.rules.core.util.isOverride
 import com.twitter.rules.core.util.modifierParameter
 import com.twitter.rules.core.util.returnsValue
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
-class ComposeModifierMissingCheck : TwitterKtlintRule("twitter-compose:modifier-check") {
+class ComposeModifierMissingCheck : TwitterKtlintRule("twitter-compose:modifier-missing-check") {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
         // We want to find all composable functions that:
@@ -24,24 +22,8 @@ class ComposeModifierMissingCheck : TwitterKtlintRule("twitter-compose:modifier-
             return
         }
 
-        // First we look for a modifier param.
-        function.modifierParameter?.let { modifierParameter ->
-            // If found, we have to check if it has a default value, which should be `Modifier`
-
-            if (!modifierParameter.hasDefaultValue()) {
-                emitter.report(modifierParameter, MissingModifierDefaultParam, true)
-            }
-
-            // This error is easily auto fixable, we just inject ` = Modifier` to the param
-            if (autoCorrect) {
-                val lastToken = modifierParameter.node.lastChildLeafOrSelf() as LeafPsiElement
-                val currentText = lastToken.text
-                lastToken.rawReplaceWithText("$currentText = Modifier")
-            }
-
-            // As we found a modifier, we can bail here.
-            return
-        }
+        // If there is a modifier param, we bail
+        if (function.modifierParameter != null) return
 
         // In case we didn't find any `modifier` parameters, we check if it emits content and report the error if so.
         if (function.emitsContent) {
@@ -50,12 +32,6 @@ class ComposeModifierMissingCheck : TwitterKtlintRule("twitter-compose:modifier-
     }
 
     companion object {
-        val MissingModifierDefaultParam = """
-            This @Composable function has a modifier parameter but it doesn't have a default value.
-
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#when-should-i-expose-modifier-parameters for more information.
-        """.trimIndent()
-
         val MissingModifierContentComposable = """
             This @Composable function emits content but doesn't have a modifier parameter.
 

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtValueArgumentName
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
-class ComposeModifierUsedOnceCheck : TwitterKtlintRule("twitter-compose:modifier-used-once-check") {
+class ComposeModifierReusedCheck : TwitterKtlintRule("twitter-compose:modifier-reused-check") {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
         if (!function.emitsContent) return

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
@@ -1,0 +1,39 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.core.ast.lastChildLeafOrSelf
+import com.twitter.rules.core.Emitter
+import com.twitter.rules.core.ktlint.TwitterKtlintRule
+import com.twitter.rules.core.report
+import com.twitter.rules.core.util.definedInInterface
+import com.twitter.rules.core.util.isModifier
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposeModifierWithoutDefaultCheck : TwitterKtlintRule("twitter-compose:modifier-without-default-check") {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        if (function.definedInInterface) return
+
+        // Look for modifier params in the composable signature, and if any without a default value is found, error out.
+        function.valueParameters.filter { it.isModifier }
+            .filterNot { it.hasDefaultValue() }
+            .forEach { modifierParameter ->
+                emitter.report(modifierParameter, MissingModifierDefaultParam, true)
+
+                // This error is easily auto fixable, we just inject ` = Modifier` to the param
+                if (autoCorrect) {
+                    val lastToken = modifierParameter.node.lastChildLeafOrSelf() as LeafPsiElement
+                    val currentText = lastToken.text
+                    lastToken.rawReplaceWithText("$currentText = Modifier")
+                }
+            }
+    }
+
+    companion object {
+        val MissingModifierDefaultParam = """
+            This @Composable function has a modifier parameter but it doesn't have a default value.
+
+            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#modifiers-should-have-default-parameters for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
@@ -36,7 +36,9 @@ class ComposeParameterOrderCheck : TwitterKtlintRule("twitter-compose:param-orde
 
         // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
         // about that case. We will sort the params with defaults so that the modifier(s) go first.
-        val sortedWithDefaults = withDefaults.sortedByDescending { it.isModifier }
+        val sortedWithDefaults = withDefaults.sortedWith(
+            compareByDescending<KtParameter> { it.isModifier }.thenByDescending { it.name == "modifier" }
+        )
 
         // We create our ideal ordering of params for the ideal composable.
         val properOrder = withoutDefaults + sortedWithDefaults + trailingLambda

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -7,7 +7,8 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
     override fun get(): RuleSet = RuleSet(
         "twitter-compose",
         ComposeModifierMissingCheck(),
-        ComposeModifierUsedOnceCheck(),
+        ComposeModifierReusedCheck(),
+        ComposeModifierWithoutDefaultCheck(),
         ComposeMultipleContentEmittersCheck(),
         ComposeMutableParametersCheck(),
         ComposeNamingCheck(),

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
@@ -92,58 +92,6 @@ class ComposeModifierMissingCheckTest {
     }
 
     @Test
-    fun `errors when a Composable has modifiers but without default values, and is able to auto fixing it`() {
-        @Language("kotlin")
-        val composableCode = """
-                @Composable
-                fun Something(modifier: Modifier) {
-                    Row(modifier = modifier) {
-                    }
-                }
-        """.trimIndent()
-
-        modifierRuleAssertThat(composableCode)
-            .hasLintViolation(
-                line = 2,
-                col = 15,
-                detail = ComposeModifierMissingCheck.MissingModifierDefaultParam
-            )
-            .isFormattedAs(
-                """
-                @Composable
-                fun Something(modifier: Modifier = Modifier) {
-                    Row(modifier = modifier) {
-                    }
-                }
-                """.trimIndent()
-            )
-    }
-
-    @Test
-    fun `passes when a Composable has modifiers with defaults`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier = Modifier) {
-                    Row(modifier = modifier) {
-                    }
-                }
-                @Composable
-                fun Something(modifier: Modifier = Modifier.fillMaxSize()) {
-                    Row(modifier = modifier) {
-                    }
-                }
-                @Composable
-                fun Something(modifier: Modifier = SomeOtherValueFromSomeConstant) {
-                    Row(modifier = modifier) {
-                    }
-                }
-            """.trimIndent()
-        modifierRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
     fun `non-public visibility Composables are ignored`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
@@ -5,9 +5,9 @@ import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
-class ComposeModifierUsedOnceCheckTest {
+class ComposeModifierReusedCheckTest {
 
-    private val modifierRuleAssertThat = ComposeModifierUsedOnceCheck().assertThat()
+    private val modifierRuleAssertThat = ComposeModifierReusedCheck().assertThat()
 
     @Test
     fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
@@ -48,47 +48,47 @@ class ComposeModifierUsedOnceCheckTest {
             LintViolation(
                 line = 3,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 4,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 9,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 11,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 16,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 19,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 20,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 25,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 26,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
         )
     }
@@ -123,32 +123,32 @@ class ComposeModifierUsedOnceCheckTest {
             LintViolation(
                 line = 3,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 4,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 9,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 11,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 17,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 18,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
         )
     }
@@ -186,37 +186,37 @@ class ComposeModifierUsedOnceCheckTest {
             LintViolation(
                 line = 6,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 8,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 9,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 12,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 16,
                 col = 5,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 20,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             ),
             LintViolation(
                 line = 21,
                 col = 9,
-                detail = ComposeModifierUsedOnceCheck.ModifierShouldBeUsedOnceOnly
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
         )
     }

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
@@ -1,0 +1,68 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierWithoutDefaultCheckTest {
+
+    private val modifierRuleAssertThat = ComposeModifierWithoutDefaultCheck().assertThat()
+
+    @Test
+    fun `errors when a Composable has modifiers but without default values, and is able to auto fix it`() {
+        @Language("kotlin")
+        val composableCode = """
+                @Composable
+                fun Something(modifier: Modifier) { }
+                @Composable
+                fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
+        """.trimIndent()
+
+        modifierRuleAssertThat(composableCode)
+            .hasLintViolations(
+                LintViolation(
+                    line = 2,
+                    col = 15,
+                    detail = ComposeModifierWithoutDefaultCheck.MissingModifierDefaultParam
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 46,
+                    detail = ComposeModifierWithoutDefaultCheck.MissingModifierDefaultParam
+                )
+            )
+            .isFormattedAs(
+                """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) { }
+                @Composable
+                fun Something(modifier: Modifier = Modifier, modifier2: Modifier = Modifier) { }
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `passes when a Composable has modifiers with defaults`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Row(modifier = modifier) {
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier.fillMaxSize()) {
+                    Row(modifier = modifier) {
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = SomeOtherValueFromSomeConstant) {
+                    Row(modifier = modifier) {
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
@@ -14,7 +14,6 @@ class ComposeParameterOrderCheckTest {
     fun `no errors when ordering is correct`() {
         @Language("kotlin")
         val code = """
-            @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, other: String = "1", other2: String = "2") { }
 
             @Composable
@@ -22,6 +21,9 @@ class ComposeParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
         """.trimIndent()
         orderingRuleAssertThat(code).hasNoLintViolations()
     }
@@ -41,6 +43,9 @@ class ComposeParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
         """.trimIndent()
         orderingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
             LintViolation(
@@ -73,6 +78,14 @@ class ComposeParameterOrderCheckTest {
                 detail = createErrorMessage(
                     currentOrder = "text: String = \"123\", modifier: Modifier = Modifier, lambda: () -> Unit",
                     properOrder = "modifier: Modifier = Modifier, text: String = \"123\", lambda: () -> Unit"
+                )
+            ),
+            LintViolation(
+                line = 14,
+                col = 5,
+                detail = createErrorMessage(
+                    currentOrder = "text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit",
+                    properOrder = "text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit"
                 )
             )
         )


### PR DESCRIPTION
In this patch, I am separating the two modifier rules that were bndled in ComposeModifierMissingCheck. I moved the missing default modifier one to its own checker, ComposeModifierWithoutDefaultCheck, so it can be disabled individually if needed. They also don't have the same requirements, so this is fair.
When looking at the docs to write the rules.md blurb, I noticed there was an issue in the ordering rule related to modifier names, so I added this to the patch as well as it's all about fixing modifier rules.