### PR TITLE
Add ComposeModifierComposableCheck to detect composable modifier extension factory functions

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -199,3 +199,13 @@ Composables that accept a Modifier as a parameter to be applied to the whole com
 Mode info: [Modifier documentation](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier)
 
 Related rule: [twitter-compose:modifier-without-default-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt)
+
+### Avoid Modifier extension factory functions
+
+Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use `Modifier.composed` instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+
+Composed modifiers may be created outside of composition, shared across elements, and declared as top-level constants, making them more flexible than modifiers that can only be created via a `@Composable` function call, and easier to avoid accidentally sharing state across elements.
+
+More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Composed modifiers in API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#composed-modifiers)
+
+Related rule: [twitter-compose:modifier-composable-check](https://github.com/twitter/compose-rules/blob/main/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt)

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
@@ -1,0 +1,25 @@
+package com.twitter.rules.ktlint.compose
+
+import com.twitter.rules.core.Emitter
+import com.twitter.rules.core.ktlint.TwitterKtlintRule
+import com.twitter.rules.core.report
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposeModifierComposableCheck : TwitterKtlintRule("twitter-compose:modifier-composable-check") {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        val receiverTypeReference = function.receiverTypeReference
+        if (receiverTypeReference != null && receiverTypeReference.text != "Modifier") return
+
+        emitter.report(function, ComposableModifier)
+    }
+
+    companion object {
+        val ComposableModifier = """
+            Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
+            You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+
+            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#avoid-modifier-extension-factory-functions for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.RuleSetProvider
 class TwitterComposeRuleSetProvider : RuleSetProvider {
     override fun get(): RuleSet = RuleSet(
         "twitter-compose",
+        ComposeModifierComposableCheck(),
         ComposeModifierMissingCheck(),
         ComposeModifierReusedCheck(),
         ComposeModifierWithoutDefaultCheck(),

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
@@ -1,0 +1,36 @@
+package com.twitter.rules.ktlint.compose
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.LintViolation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierComposableCheckTest {
+
+    private val modifierRuleAssertThat = ComposeModifierComposableCheck().assertThat()
+
+    @Test
+    fun `errors when a composable Modifier extension is detected`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Modifier.something(): Modifier { }
+                @Composable
+                fun Modifier.something() = somethingElse()
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 14,
+                detail = ComposeModifierComposableCheck.ComposableModifier
+            ),
+            LintViolation(
+                line = 4,
+                col = 14,
+                detail = ComposeModifierComposableCheck.ComposableModifier
+            )
+        )
+    }
+}


### PR DESCRIPTION
Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions. Folks should be using `Modifier.composed` instead.