### PR TITLE
Add copyright headers and enforce through spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.spotless" version "6.8.0"
+    id "com.diffplug.spotless" version "6.9.1"
 }
 
 allprojects {
@@ -27,10 +27,12 @@ subprojects {
         kotlin {
             target "**/*.kt"
             ktlint(libs.versions.ktlint.get())
+            licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {
             target "**/*.gradle"
             greclipse().configFile(rootProject.file("spotless/greclipse.properties"))
+            licenseHeaderFile rootProject.file('spotless/copyright.txt'), '(buildscript|apply|import|plugins)'
         }
     }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { compile ->

--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id 'org.jetbrains.kotlin.jvm'
 }

--- a/core/common/src/main/kotlin/com/twitter/rules/core/Emitter.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/Emitter.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core
 
 import com.twitter.rules.core.util.startOffsetFromName

--- a/core/common/src/main/kotlin/com/twitter/rules/core/KtElementVisitors.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/KtElementVisitors.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core
 
 import org.jetbrains.kotlin.psi.KtClass

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T =

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/KtAnnotateds.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/KtAnnotateds.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.psi.KtAnnotated

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/KtImportLists.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/KtImportLists.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.KtNodeTypes

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.psi.KtParameter

--- a/core/common/src/main/kotlin/com/twitter/rules/core/util/PsiElements.kt
+++ b/core/common/src/main/kotlin/com/twitter/rules/core/util/PsiElements.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement

--- a/core/ktlint/build.gradle
+++ b/core/ktlint/build.gradle
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id 'org.jetbrains.kotlin.jvm'
 }

--- a/core/ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/TwitterKtlintRule.kt
+++ b/core/ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/TwitterKtlintRule.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.ktlint
 
 import com.pinterest.ktlint.core.Rule

--- a/rules/ktlint/build.gradle
+++ b/rules/ktlint/build.gradle
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id 'org.jetbrains.kotlin.jvm'
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.core.ast.lastChildLeafOrSelf

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.twitter.rules.core.Emitter

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.core.ast.firstChildLeafOrSelf

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.core.RuleSet

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProviderTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProviderTest.kt
@@ -1,3 +1,5 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
 import com.pinterest.ktlint.test.RuleSetProviderTest

--- a/spotless/copyright.txt
+++ b/spotless/copyright.txt
@@ -1,0 +1,2 @@
+// Copyright $YEAR Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Add spotless configuration (and bump to latest version, given that we are touching this) to enforce copyright headers to be added to the project automatically.