### PR TITLE
Add mkdocs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,37 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - main
+    #tags: # Re-enable once the first docs are up, and automatic tagging of releases is configured
+    #  - v*
+
+jobs:
+  deploy_docs:
+    runs-on: ubuntu-latest
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install mkdocs
+          python3 -m pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,24 @@ A big challenge to face when a big team with a large codebase starts adopting Co
 
 Compose is 🔝, allows for amazing things, but has a bunch of footguns to be aware of. [See the thread](https://twitter.com/mrmans0n/status/1507390768796909571).
 
-This is where these ktlint rules come in. We want to detect all the potential issues even before they reach the code review state, and foster a healthy Compose adoption.
+This is where these static checks come in. We want to detect all the potential issues even before they reach the code review state, and foster a healthy Compose adoption.
+
+## Using the custom ruleset with ktlint
+
+### With ktlint-gradle
+
+If using [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle), you can specify the dependency on this set of rules by using the `ktlintRuleset`.
+
+```groovy
+dependencies {
+    ktlintRuleset "com.twitter.rules.compose:ktlint:<VERSION>"
+}
+```
+
+### With spotless
+
+If using [Spotless](https://github.com/diffplug/spotless), there is currently a workaround on how to do that described [in this issue](https://github.com/diffplug/spotless/issues/1220).
+
 
 ## Disabling a specific rule
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,41 @@
+site_name: 'Twitter Jetpack Compose Rules'
+site_description: 'Twitter Compose Rules is a set of custom ktlint rules to ensure that your composables do not fall into common pitfalls'
+site_author: 'Twitter'
+site_url: 'https://twitter.github.io/compose-rules/'
+edit_uri: 'tree/main/docs/'
+remote_branch: gh-pages
+
+docs_dir: docs
+
+repo_name: 'Compose Rules'
+repo_url: 'https://github.com/twitter/compose-rules'
+
+# Navigation
+nav:
+    - 'Overview': index.md
+    - 'Ruleset': rules.md
+
+# Configuration
+theme:
+    name: 'material'
+    language: 'en'
+    palette:
+        primary: 'light blue'
+        accent: 'indigo'
+    font:
+        text: 'Roboto'
+        code: 'JetBrains Mono'
+
+# Extensions
+markdown_extensions:
+    - admonition
+    - attr_list
+    - codehilite:
+          guess_lang: false
+    - footnotes
+    - toc:
+          permalink: true
+    - pymdownx.betterem
+    - pymdownx.superfences
+    - pymdownx.tabbed
+    - pymdownx.details


### PR DESCRIPTION
I am adding mkdocs to automatically generate a gh-pages documentation off of the markdown files in docs/. For now, I am disabling the part of the rule to only generate this when pushing a release into a tag because that part is not configured yet and I want to have the docs asap.