### PR TITLE
Migrate to ktlint 0.47.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
         kotlin {
             target "**/*.kt"
             // ktlint 0.47.0 currently not supported - https://github.com/diffplug/spotless/pull/1303
-            // ktlint(libs.versions.ktlint.get())
+            ktlint("0.46.1")
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ subprojects {
         kotlin {
             target "**/*.kt"
             // ktlint 0.47.0 currently not supported - https://github.com/diffplug/spotless/pull/1303
+            // ktlint(libs.versions.ktlint.get())
             ktlint("0.46.1")
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.spotless" version "6.9.1"
+    id "com.diffplug.spotless" version "6.10.0"
 }
 
 allprojects {
@@ -26,7 +26,8 @@ subprojects {
     spotless {
         kotlin {
             target "**/*.kt"
-            ktlint(libs.versions.ktlint.get())
+            // ktlint 0.47.0 currently not supported - https://github.com/diffplug/spotless/pull/1303
+            // ktlint(libs.versions.ktlint.get())
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {

--- a/core/ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/TwitterKtlintRule.kt
+++ b/core/ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/TwitterKtlintRule.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 
 abstract class TwitterKtlintRule(id: String) : Rule(id), KtElementVisitors {
 
-    final override fun visit(
+    final override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
-kotlin = "1.7.0"
-ktlint = "0.46.1"
-junit = "5.8.2"
+kotlin = "1.7.10"
+ktlint = "0.47.0"
+junit = "5.9.0"
 
 [libraries]
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
-ktlint-gradlePlugin = "org.jlleitschuh.gradle:ktlint-gradle:10.3.0"
+ktlint-gradlePlugin = "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 
-gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.20.0"
+gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.21.0"
 
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
-assertj = "org.assertj:assertj-core:3.22.0"
+assertj = "org.assertj:assertj-core:3.23.1"

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -1,13 +1,22 @@
 // Copyright 2022 Twitter, Inc.
 // SPDX-License-Identifier: Apache-2.0
+@file:Suppress("DEPRECATION")
+
 package com.twitter.rules.ktlint.compose
 
+import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
+import com.pinterest.ktlint.core.RuleSetProviderV2
 
-class TwitterComposeRuleSetProvider : RuleSetProvider {
+class TwitterComposeRuleSetProvider :
+    RuleSetProviderV2(CustomRuleSetId, RuleSetAbout),
+    RuleSetProvider {
+
+    // Pre-0.47.0 ruleset (will go away in 0.48.0)
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun get(): RuleSet = RuleSet(
-        "twitter-compose",
+        CustomRuleSetId,
         ComposeModifierComposableCheck(),
         ComposeModifierMissingCheck(),
         ComposeModifierReusedCheck(),
@@ -17,6 +26,31 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
         ComposeNamingCheck(),
         ComposeParameterOrderCheck(),
         ComposeRememberMissingCheck(),
-        ComposeViewModelForwardingCheck()
+        ComposeViewModelForwardingCheck(),
     )
+
+    // 0.47.0+ ruleset
+    override fun getRuleProviders(): Set<RuleProvider> = setOf(
+        RuleProvider { ComposeModifierComposableCheck() },
+        RuleProvider { ComposeModifierMissingCheck() },
+        RuleProvider { ComposeModifierReusedCheck() },
+        RuleProvider { ComposeModifierWithoutDefaultCheck() },
+        RuleProvider { ComposeMultipleContentEmittersCheck() },
+        RuleProvider { ComposeMutableParametersCheck() },
+        RuleProvider { ComposeNamingCheck() },
+        RuleProvider { ComposeParameterOrderCheck() },
+        RuleProvider { ComposeRememberMissingCheck() },
+        RuleProvider { ComposeViewModelForwardingCheck() },
+    )
+
+    private companion object {
+        private val RuleSetAbout = About(
+            maintainer = "Twitter, Inc",
+            description = "Static checks to aid with a healthy adoption of Jetpack Compose",
+            license = "Apache License, Version 2.0",
+            repositoryUrl = "https://github.com/twitter/compose-rules/",
+            issueTrackerUrl = "https://github.com/twitter/compose-rules/issues",
+        )
+        const val CustomRuleSetId = "twitter-compose"
+    }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/TwitterComposeRuleSetProvider.kt
@@ -26,7 +26,7 @@ class TwitterComposeRuleSetProvider :
         ComposeNamingCheck(),
         ComposeParameterOrderCheck(),
         ComposeRememberMissingCheck(),
-        ComposeViewModelForwardingCheck(),
+        ComposeViewModelForwardingCheck()
     )
 
     // 0.47.0+ ruleset
@@ -40,7 +40,7 @@ class TwitterComposeRuleSetProvider :
         RuleProvider { ComposeNamingCheck() },
         RuleProvider { ComposeParameterOrderCheck() },
         RuleProvider { ComposeRememberMissingCheck() },
-        RuleProvider { ComposeViewModelForwardingCheck() },
+        RuleProvider { ComposeViewModelForwardingCheck() }
     )
 
     private companion object {
@@ -49,7 +49,7 @@ class TwitterComposeRuleSetProvider :
             description = "Static checks to aid with a healthy adoption of Jetpack Compose",
             license = "Apache License, Version 2.0",
             repositoryUrl = "https://github.com/twitter/compose-rules/",
-            issueTrackerUrl = "https://github.com/twitter/compose-rules/issues",
+            issueTrackerUrl = "https://github.com/twitter/compose-rules/issues"
         )
         const val CustomRuleSetId = "twitter-compose"
     }

--- a/rules/ktlint/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProviderV2
+++ b/rules/ktlint/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProviderV2
@@ -1,0 +1,1 @@
+com.twitter.rules.ktlint.compose.TwitterComposeRuleSetProvider

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeModifierComposableCheckTest {
 
-    private val modifierRuleAssertThat = ComposeModifierComposableCheck().assertThat()
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierComposableCheck() }
 
     @Test
     fun `errors when a composable Modifier extension is detected`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeModifierMissingCheckTest {
 
-    private val modifierRuleAssertThat = ComposeModifierMissingCheck().assertThat()
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierMissingCheck() }
 
     @Test
     fun `errors when a Composable has a layout inside and it doesn't have a modifier`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeModifierReusedCheckTest {
 
-    private val modifierRuleAssertThat = ComposeModifierReusedCheck().assertThat()
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierReusedCheck() }
 
-    @Test
-    fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Row(modifier) {
@@ -46,60 +46,60 @@ class ComposeModifierReusedCheckTest {
                 }
             """.trimIndent()
 
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 3,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 4,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 9,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 11,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 16,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 19,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 20,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 25,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 26,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 11,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 16,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 20,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 25,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 26,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `errors when the modifier parameter of a Composable is tweaked or reassigned and reused`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when the modifier parameter of a Composable is tweaked or reassigned and reused`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
@@ -121,45 +121,45 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 3,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 4,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 9,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 11,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 17,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 18,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 11,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 17,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 18,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `errors when multiple Composables use the modifier even when it's been assigned to a new val`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when multiple Composables use the modifier even when it's been assigned to a new val`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier) {
                     val tweakedModifier = Modifier.then(modifier).fillMaxWidth()
@@ -184,50 +184,50 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 6,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 8,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 9,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 12,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 16,
-                col = 5,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 20,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-            ),
-            LintViolation(
-                line = 21,
-                col = 9,
-                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 6,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 16,
+                    col = 5,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 20,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                ),
+                LintViolation(
+                    line = 21,
+                    col = 9,
+                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `passes when a Composable only passes its modifier parameter to the root level layout`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `passes when a Composable only passes its modifier parameter to the root level layout`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier) {
@@ -262,14 +262,14 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-        modifierRuleAssertThat(code).hasNoLintViolations()
-    }
+            modifierRuleAssertThat(code).hasNoLintViolations()
+        }
 
-    @Test
-    fun `passes when modifiers are reused for mutually exclusive branches`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `passes when modifiers are reused for mutually exclusive branches`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier = Modifier) {
                     if (someCondition) {
@@ -279,14 +279,14 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-        modifierRuleAssertThat(code).hasNoLintViolations()
-    }
+            modifierRuleAssertThat(code).hasNoLintViolations()
+        }
 
-    @Test
-    fun `passes when used on vals with lambdas`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `passes when used on vals with lambdas`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
@@ -318,6 +318,6 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-        modifierRuleAssertThat(code).hasNoLintViolations()
+            modifierRuleAssertThat(code).hasNoLintViolations()
+        }
     }
-}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheckTest.kt
@@ -11,11 +11,11 @@ class ComposeModifierReusedCheckTest {
 
     private val modifierRuleAssertThat = assertThatRule { ComposeModifierReusedCheck() }
 
-        @Test
-        fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when the modifier parameter of a Composable is used more than once by siblings or parent-children`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Row(modifier) {
@@ -46,60 +46,60 @@ class ComposeModifierReusedCheckTest {
                 }
             """.trimIndent()
 
-            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 3,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 4,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 9,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 11,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 16,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 19,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 20,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 25,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 26,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                )
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 4,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 9,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 11,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 16,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 19,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 20,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 25,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 26,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
-        }
+        )
+    }
 
-        @Test
-        fun `errors when the modifier parameter of a Composable is tweaked or reassigned and reused`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when the modifier parameter of a Composable is tweaked or reassigned and reused`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
@@ -121,45 +121,45 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 3,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 4,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 9,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 11,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 17,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 18,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                )
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 4,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 9,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 11,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 17,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 18,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
-        }
+        )
+    }
 
-        @Test
-        fun `errors when multiple Composables use the modifier even when it's been assigned to a new val`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when multiple Composables use the modifier even when it's been assigned to a new val`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier) {
                     val tweakedModifier = Modifier.then(modifier).fillMaxWidth()
@@ -184,50 +184,50 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-            modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 6,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 8,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 9,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 12,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 16,
-                    col = 5,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 20,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                ),
-                LintViolation(
-                    line = 21,
-                    col = 9,
-                    detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
-                )
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 6,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 8,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 9,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 12,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 16,
+                col = 5,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 20,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 21,
+                col = 9,
+                detail = ComposeModifierReusedCheck.ModifierShouldBeUsedOnceOnly
             )
-        }
+        )
+    }
 
-        @Test
-        fun `passes when a Composable only passes its modifier parameter to the root level layout`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `passes when a Composable only passes its modifier parameter to the root level layout`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier) {
@@ -262,14 +262,14 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-            modifierRuleAssertThat(code).hasNoLintViolations()
-        }
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 
-        @Test
-        fun `passes when modifiers are reused for mutually exclusive branches`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `passes when modifiers are reused for mutually exclusive branches`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier = Modifier) {
                     if (someCondition) {
@@ -279,14 +279,14 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-            modifierRuleAssertThat(code).hasNoLintViolations()
-        }
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 
-        @Test
-        fun `passes when used on vals with lambdas`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `passes when used on vals with lambdas`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
@@ -318,6 +318,6 @@ class ComposeModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
-            modifierRuleAssertThat(code).hasNoLintViolations()
-        }
+        modifierRuleAssertThat(code).hasNoLintViolations()
     }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeModifierWithoutDefaultCheckTest {
 
-    private val modifierRuleAssertThat = ComposeModifierWithoutDefaultCheck().assertThat()
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierWithoutDefaultCheck() }
 
     @Test
     fun `errors when a Composable has modifiers but without default values, and is able to auto fix it`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
@@ -11,11 +11,11 @@ class ComposeMultipleContentEmittersCheckTest {
 
     private val emittersRuleAssertThat = assertThatRule { ComposeMultipleContentEmittersCheck() }
 
-        @Test
-        fun `passes when only one item emits up at the top level`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `passes when only one item emits up at the top level`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something() {
                     val something = rememberWhatever()
@@ -27,14 +27,14 @@ class ComposeMultipleContentEmittersCheckTest {
                     }
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasNoLintViolations()
-        }
+        emittersRuleAssertThat(code).hasNoLintViolations()
+    }
 
-        @Test
-        fun `passes when the composable is an extension function`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `passes when the composable is an extension function`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun ColumnScope.Something() {
                     Text("Hi")
@@ -46,14 +46,14 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Hola")
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasNoLintViolations()
-        }
+        emittersRuleAssertThat(code).hasNoLintViolations()
+    }
 
-        @Test
-        fun `errors when a Composable function has more than one UI emitter at the top level`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when a Composable function has more than one UI emitter at the top level`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something() {
                     Text("Hi")
@@ -65,25 +65,25 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Hola")
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 2,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-                ),
-                LintViolation(
-                    line = 7,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-                )
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+            ),
+            LintViolation(
+                line = 7,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
             )
-        }
+        )
+    }
 
-        @Test
-        fun `errors when a Composable function has more than one indirect UI emitter at the top level`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when a Composable function has more than one indirect UI emitter at the top level`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something1() {
                     Something2()
@@ -107,25 +107,25 @@ class ComposeMultipleContentEmittersCheckTest {
                     Something4()
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 6,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-                ),
-                LintViolation(
-                    line = 19,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-                )
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 6,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+            ),
+            LintViolation(
+                line = 19,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
             )
-        }
+        )
+    }
 
-        @Test
-        fun `make sure to not report twice the same composable`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `make sure to not report twice the same composable`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something() {
                     Text("Hi")
@@ -137,20 +137,20 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Alo")
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 2,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-                )
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
             )
-        }
+        )
+    }
 
-        @Test
-        fun `error out when detecting a content emitting composable that returns something other than unit`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `error out when detecting a content emitting composable that returns something other than unit`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(): String { // This one emits content directly and should fail
                     Text("Hi")
@@ -166,17 +166,17 @@ class ComposeMultipleContentEmittersCheckTest {
                     HorizonIcon(icon = HorizonIcon.Arrow)
                 }
             """.trimIndent()
-            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 2,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
-                ),
-                LintViolation(
-                    line = 7,
-                    col = 5,
-                    detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
-                )
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
+            ),
+            LintViolation(
+                line = 7,
+                col = 5,
+                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
             )
-        }
+        )
     }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheckTest.kt
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeMultipleContentEmittersCheckTest {
 
-    private val emittersRuleAssertThat = ComposeMultipleContentEmittersCheck().assertThat()
+    private val emittersRuleAssertThat = assertThatRule { ComposeMultipleContentEmittersCheck() }
 
-    @Test
-    fun `passes when only one item emits up at the top level`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `passes when only one item emits up at the top level`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something() {
                     val something = rememberWhatever()
@@ -27,14 +27,14 @@ class ComposeMultipleContentEmittersCheckTest {
                     }
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasNoLintViolations()
-    }
+            emittersRuleAssertThat(code).hasNoLintViolations()
+        }
 
-    @Test
-    fun `passes when the composable is an extension function`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `passes when the composable is an extension function`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun ColumnScope.Something() {
                     Text("Hi")
@@ -46,14 +46,14 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Hola")
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasNoLintViolations()
-    }
+            emittersRuleAssertThat(code).hasNoLintViolations()
+        }
 
-    @Test
-    fun `errors when a Composable function has more than one UI emitter at the top level`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when a Composable function has more than one UI emitter at the top level`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something() {
                     Text("Hi")
@@ -65,25 +65,25 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Hola")
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-            ),
-            LintViolation(
-                line = 7,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `errors when a Composable function has more than one indirect UI emitter at the top level`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when a Composable function has more than one indirect UI emitter at the top level`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something1() {
                     Something2()
@@ -107,25 +107,25 @@ class ComposeMultipleContentEmittersCheckTest {
                     Something4()
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 6,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
-            ),
-            LintViolation(
-                line = 19,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 6,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `make sure to not report twice the same composable`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `make sure to not report twice the same composable`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something() {
                     Text("Hi")
@@ -137,20 +137,20 @@ class ComposeMultipleContentEmittersCheckTest {
                     Text("Alo")
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.MultipleContentEmittersDetected
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `error out when detecting a content emitting composable that returns something other than unit`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `error out when detecting a content emitting composable that returns something other than unit`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(): String { // This one emits content directly and should fail
                     Text("Hi")
@@ -166,17 +166,17 @@ class ComposeMultipleContentEmittersCheckTest {
                     HorizonIcon(icon = HorizonIcon.Arrow)
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
-            ),
-            LintViolation(
-                line = 7,
-                col = 5,
-                detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
+            emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 5,
+                    detail = ComposeMultipleContentEmittersCheck.ContentEmitterReturningValuesToo
+                )
             )
-        )
+        }
     }
-}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeMutableParametersCheckTest {
 
-    private val mutableParamRuleAssertThat = ComposeMutableParametersCheck().assertThat()
+    private val mutableParamRuleAssertThat = assertThatRule { ComposeMutableParametersCheck() }
 
-    @Test
-    fun `errors when a Composable has a mutable parameter`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `errors when a Composable has a mutable parameter`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(a: MutableState<String>) {}
                 @Composable
@@ -25,40 +25,40 @@ class ComposeMutableParametersCheckTest {
                 @Composable
                 fun Something(a: MutableMap<String, String>) {}
             """.trimIndent()
-        mutableParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 15,
-                detail = ComposeMutableParametersCheck.MutableParameterInCompose
-            ),
-            LintViolation(
-                line = 4,
-                col = 15,
-                detail = ComposeMutableParametersCheck.MutableParameterInCompose
-            ),
-            LintViolation(
-                line = 6,
-                col = 15,
-                detail = ComposeMutableParametersCheck.MutableParameterInCompose
-            ),
-            LintViolation(
-                line = 8,
-                col = 15,
-                detail = ComposeMutableParametersCheck.MutableParameterInCompose
+            mutableParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 15,
+                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 15,
+                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 15,
+                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 15,
+                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
+                )
             )
-        )
-    }
+        }
 
-    @Test
-    fun `no errors when a Composable has valid parameters`() {
-        @Language("kotlin")
-        val code =
-            """
+        @Test
+        fun `no errors when a Composable has valid parameters`() {
+            @Language("kotlin")
+            val code =
+                """
                 @Composable
                 fun Something(a: String, b: (Int) -> Unit) {}
                 @Composable
                 fun Something(a: State<String>) {}
             """.trimIndent()
-        mutableParamRuleAssertThat(code).hasNoLintViolations()
+            mutableParamRuleAssertThat(code).hasNoLintViolations()
+        }
     }
-}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheckTest.kt
@@ -11,11 +11,11 @@ class ComposeMutableParametersCheckTest {
 
     private val mutableParamRuleAssertThat = assertThatRule { ComposeMutableParametersCheck() }
 
-        @Test
-        fun `errors when a Composable has a mutable parameter`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `errors when a Composable has a mutable parameter`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(a: MutableState<String>) {}
                 @Composable
@@ -25,40 +25,40 @@ class ComposeMutableParametersCheckTest {
                 @Composable
                 fun Something(a: MutableMap<String, String>) {}
             """.trimIndent()
-            mutableParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 2,
-                    col = 15,
-                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
-                ),
-                LintViolation(
-                    line = 4,
-                    col = 15,
-                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
-                ),
-                LintViolation(
-                    line = 6,
-                    col = 15,
-                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
-                ),
-                LintViolation(
-                    line = 8,
-                    col = 15,
-                    detail = ComposeMutableParametersCheck.MutableParameterInCompose
-                )
+        mutableParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 15,
+                detail = ComposeMutableParametersCheck.MutableParameterInCompose
+            ),
+            LintViolation(
+                line = 4,
+                col = 15,
+                detail = ComposeMutableParametersCheck.MutableParameterInCompose
+            ),
+            LintViolation(
+                line = 6,
+                col = 15,
+                detail = ComposeMutableParametersCheck.MutableParameterInCompose
+            ),
+            LintViolation(
+                line = 8,
+                col = 15,
+                detail = ComposeMutableParametersCheck.MutableParameterInCompose
             )
-        }
+        )
+    }
 
-        @Test
-        fun `no errors when a Composable has valid parameters`() {
-            @Language("kotlin")
-            val code =
-                """
+    @Test
+    fun `no errors when a Composable has valid parameters`() {
+        @Language("kotlin")
+        val code =
+            """
                 @Composable
                 fun Something(a: String, b: (Int) -> Unit) {}
                 @Composable
                 fun Something(a: State<String>) {}
             """.trimIndent()
-            mutableParamRuleAssertThat(code).hasNoLintViolations()
-        }
+        mutableParamRuleAssertThat(code).hasNoLintViolations()
     }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeNamingCheckTest {
 
-    private val namingRuleAssertThat = ComposeNamingCheck().assertThat()
+    private val namingRuleAssertThat = assertThatRule { ComposeNamingCheck() }
 
     @Test
     fun `passes when a composable that returns values is lowercase`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheckTest.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.twitter.rules.ktlint.compose.ComposeParameterOrderCheck.Companion.createErrorMessage
 import org.intellij.lang.annotations.Language
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 class ComposeParameterOrderCheckTest {
 
-    private val orderingRuleAssertThat = ComposeParameterOrderCheck().assertThat()
+    private val orderingRuleAssertThat = assertThatRule { ComposeParameterOrderCheck() }
 
     @Test
     fun `no errors when ordering is correct`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeRememberMissingCheckTest {
 
-    private val rememberRuleAssertThat = ComposeRememberMissingCheck().assertThat()
+    private val rememberRuleAssertThat = assertThatRule { ComposeRememberMissingCheck() }
 
     @Test
     fun `passes when a non-remembered mutableStateOf is used outside of a Composable`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheckTest.kt
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
 class ComposeViewModelForwardingCheckTest {
 
-    private val forwardingRuleAssertThat = ComposeViewModelForwardingCheck().assertThat()
+    private val forwardingRuleAssertThat = assertThatRule { ComposeViewModelForwardingCheck() }
 
     @Test
     fun `allows the forwarding of ViewModels in overridden Composable functions`() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheckTest.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.ktlint.compose
 
-import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThat
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.params.ParameterizedTest
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class ComposeViewModelInjectionCheckTest {
 
-    private val injectionRuleAssertThat = ComposeViewModelInjectionCheck().assertThat()
+    private val injectionRuleAssertThat = assertThatRule { ComposeViewModelInjectionCheck() }
 
     @ParameterizedTest
     @ValueSource(strings = ["viewModel", "weaverViewModel"])


### PR DESCRIPTION
There are a bunch of [breaking API changes](https://github.com/pinterest/ktlint/releases/tag/0.47.0) in the newest version of ktlint. Basically all rulesets need to be redefined. In 0.47.0 versions the previous ruleset versions coexist with the newers, so I added support for both in the mean time. In the future, the previous version of the rulesets will disappear. Also, undocumented by the migration guide, but all tests changed the way in which the assertThat classes are created, so I also updated all the tests to support the new version.

Spotless is not yet compatible with 0.47.0, so I am targeting the previous version for this own repo checks until it is (will likely [land soon](https://github.com/diffplug/spotless/pull/1303)).

I also updated all dependencies.