### PR TITLE
Update error documentation links

### DIFF
--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierComposableCheck.kt
@@ -21,7 +21,7 @@ class ComposeModifierComposableCheck : TwitterKtlintRule("twitter-compose:modifi
             Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
             You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#avoid-modifier-extension-factory-functions for more information.
+            See https://twitter.github.io/compose-rules/rules/#avoid-modifier-extension-factory-functions for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierMissingCheck.kt
@@ -37,7 +37,7 @@ class ComposeModifierMissingCheck : TwitterKtlintRule("twitter-compose:modifier-
         val MissingModifierContentComposable = """
             This @Composable function emits content but doesn't have a modifier parameter.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#when-should-i-expose-modifier-parameters for more information.
+            See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierReusedCheck.kt
@@ -123,7 +123,7 @@ class ComposeModifierReusedCheck : TwitterKtlintRule("twitter-compose:modifier-r
 
             Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other Composables.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#dont-re-use-modifiers for more information.
+            See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeModifierWithoutDefaultCheck.kt
@@ -35,7 +35,7 @@ class ComposeModifierWithoutDefaultCheck : TwitterKtlintRule("twitter-compose:mo
         val MissingModifierDefaultParam = """
             This @Composable function has a modifier parameter but it doesn't have a default value.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#modifiers-should-have-default-parameters for more information.
+            See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMultipleContentEmittersCheck.kt
@@ -106,7 +106,7 @@ class ComposeMultipleContentEmittersCheck : TwitterKtlintRule("twitter-compose:m
         val MultipleContentEmittersDetected = """
             Composable functions should only be emitting content into the composition from one source at their top level.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#do-not-emit-multiple-pieces-of-content for more information.
+            See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
         """.trimIndent()
 
         val ContentEmitterReturningValuesToo = """
@@ -114,7 +114,7 @@ class ComposeMultipleContentEmittersCheck : TwitterKtlintRule("twitter-compose:m
             If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks
             should be provided as parameters to the composable function by the caller.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#do-not-emit-multiple-pieces-of-content for more information.
+            See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeMutableParametersCheck.kt
@@ -23,7 +23,7 @@ class ComposeMutableParametersCheck : TwitterKtlintRule("twitter-compose:mutable
             Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by
             Compose to trigger recomposition when they change.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#do-not-use-inherently-mutable-types-as-parameters for more information.
+            See https://twitter.github.io/compose-rules/rules/#do-not-use-inherently-mutable-types-as-parameters for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeNamingCheck.kt
@@ -34,14 +34,14 @@ class ComposeNamingCheck : TwitterKtlintRule("twitter-compose:naming-check") {
             Composable functions that return Unit should start with an uppercase letter.
             They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
 
-            For more information: https://github.com/twitter/compose-rules/blob/main/docs/rules.md#naming-composable-functions-properly
+            See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
         """.trimIndent()
 
         val ComposablesThatReturnResultsShouldBeLowercase = """
             Composable functions that return a value should start with a lowercase letter.
             While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
 
-            For more information: https://github.com/twitter/compose-rules/blob/main/docs/rules.md#naming-composable-functions-properly
+            See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeParameterOrderCheck.kt
@@ -62,7 +62,7 @@ class ComposeParameterOrderCheck : TwitterKtlintRule("twitter-compose:param-orde
             Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
             Current params are: [$currentOrder] but should be [$properOrder].
 
-            For more information: https://github.com/twitter/compose-rules/blob/main/docs/rules.md#ordering-composable-parameters-properly
+            See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeRememberMissingCheck.kt
@@ -51,7 +51,7 @@ class ComposeRememberMissingCheck : TwitterKtlintRule("twitter-compose:remember-
             Using `$name` in a @Composable function without it being inside of a remember function.
             If you don't remember the state instance, a new state instance will be created when the function is recomposed.
 
-            For more information: https://github.com/twitter/compose-rules/blob/main/docs/rules.md#state-should-be-remembered-in-composables
+            See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelForwardingCheck.kt
@@ -49,7 +49,7 @@ class ComposeViewModelForwardingCheck : TwitterKtlintRule("twitter-compose:vm-fo
             Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using
             state hoisting.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#hoist-all-the-things for more information.
+            See https://twitter.github.io/compose-rules/rules/#hoist-all-the-things for more information.
         """.trimIndent()
     }
 }

--- a/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/rules/ktlint/compose/ComposeViewModelInjectionCheck.kt
@@ -111,7 +111,7 @@ class ComposeViewModelInjectionCheck : TwitterKtlintRule("twitter-compose:vm-inj
 
             Usages of $factoryName to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
 
-            See https://github.com/twitter/compose-rules/blob/main/docs/rules.md#make-dependencies-explicit for more information.
+            See https://twitter.github.io/compose-rules/rules/#make-dependencies-explicit for more information.
         """.trimIndent()
     }
 }


### PR DESCRIPTION
Now that the docs are deployed in gh pages, we should use that for extra documentation instead of the raw md file link.