### PR TITLE
Combine ComposeNamingChecks for detekt

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
@@ -8,13 +8,7 @@ import com.twitter.rules.core.report
 import com.twitter.rules.core.util.returnsValue
 import org.jetbrains.kotlin.psi.KtFunction
 
-class ComposeNaming(private val type: Type = Type.All) : ComposeKtVisitor {
-
-    sealed class Type(val checkReturnResults: Boolean, val checkDontReturnResults: Boolean) {
-        object All : Type(checkReturnResults = true, checkDontReturnResults = true)
-        object CheckReturnResults : Type(checkReturnResults = true, checkDontReturnResults = false)
-        object CheckDontReturnResults : Type(checkReturnResults = false, checkDontReturnResults = true)
-    }
+class ComposeNaming : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
         // If it's a block we can't know if there is a return type or not from ktlint
@@ -23,12 +17,12 @@ class ComposeNaming(private val type: Type = Type.All) : ComposeKtVisitor {
 
         if (function.returnsValue) {
             // If it returns value, the composable should start with a lowercase letter
-            if (firstLetter.isUpperCase() && type.checkReturnResults) {
+            if (firstLetter.isUpperCase()) {
                 emitter.report(function, ComposablesThatReturnResultsShouldBeLowercase)
             }
         } else {
             // If it returns Unit or doesn't have a return type, we should start with an uppercase letter
-            if (firstLetter.isLowerCase() && type.checkDontReturnResults) {
+            if (firstLetter.isLowerCase()) {
                 emitter.report(function, ComposablesThatDoNotReturnResultsShouldBeCapitalized)
             }
         }

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheck.kt
@@ -3,8 +3,6 @@
 package com.twitter.compose.rules.detekt
 
 import com.twitter.compose.rules.ComposeNaming
-import com.twitter.compose.rules.ComposeNaming.Type.CheckDontReturnResults
-import com.twitter.compose.rules.ComposeNaming.Type.CheckReturnResults
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.detekt.TwitterDetektRule
 import io.gitlab.arturbosch.detekt.api.Config
@@ -12,24 +10,17 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
 
-class ComposeNamingReturnResultsCheck(config: Config) :
+class ComposeNamingCheck(config: Config) :
     TwitterDetektRule(config),
-    ComposeKtVisitor by ComposeNaming(CheckReturnResults) {
+    ComposeKtVisitor by ComposeNaming() {
     override val issue: Issue = Issue(
         id = "naming-check",
         severity = Severity.CodeSmell,
-        description = ComposeNaming.ComposablesThatReturnResultsShouldBeLowercase,
-        debt = Debt.TEN_MINS
-    )
-}
+        description = """
+        Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
 
-class ComposeNamingDontReturnResultsCheck(config: Config) :
-    TwitterDetektRule(config),
-    ComposeKtVisitor by ComposeNaming(CheckDontReturnResults) {
-    override val issue: Issue = Issue(
-        id = "naming-check",
-        severity = Severity.CodeSmell,
-        description = ComposeNaming.ComposablesThatDoNotReturnResultsShouldBeCapitalized,
+        However, Composable functions that return a value should start with a lowercase letter instead. They should follow the standard Kotlin Coding Conventions for the naming of functions for any function annotated @Composable that returns a value other than Unit
+        """.trimIndent(),
         debt = Debt.TEN_MINS
     )
 }

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
@@ -19,10 +19,9 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
             ComposeModifierWithoutDefaultCheck(config),
             ComposeMultipleContentEmittersCheck(config),
             ComposeMutableParametersCheck(config),
-            ComposeNamingDontReturnResultsCheck(config),
-            ComposeNamingReturnResultsCheck(config),
+            ComposeNamingCheck(config),
             ComposeParameterOrderCheck(config),
-            /* ComposeRememberMissingCheck(config), */
+            ComposeRememberMissingCheck(config),
             ComposeViewModelForwardingCheck(config),
             ComposeViewModelInjectionCheck(config)
         )

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.Test
 
 class ComposeNamingCheckTest {
 
-    private val ruleReturns = ComposeNamingReturnResultsCheck(Config.empty)
-    private val ruleNotReturns = ComposeNamingDontReturnResultsCheck(Config.empty)
+    private val rule = ComposeNamingCheck(Config.empty)
 
     @Test
     fun `passes when a composable that returns values is lowercase`() {
@@ -23,8 +22,7 @@ class ComposeNamingCheckTest {
                 @Composable
                 fun myComposable(): Something { }
             """.trimIndent()
-        assertThat(ruleReturns.lint(code)).isEmpty()
-        assertThat(ruleNotReturns.lint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -37,8 +35,7 @@ class ComposeNamingCheckTest {
                 @Composable
                 fun MyComposable(): Unit { }
             """.trimIndent()
-        assertThat(ruleReturns.lint(code)).isEmpty()
-        assertThat(ruleNotReturns.lint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -57,8 +54,7 @@ class ComposeNamingCheckTest {
 
                 val whatever = @Composable { }
             """.trimIndent()
-        assertThat(ruleReturns.lint(code)).isEmpty()
-        assertThat(ruleNotReturns.lint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -69,7 +65,7 @@ class ComposeNamingCheckTest {
                 @Composable
                 fun MyComposable(): Something { }
             """.trimIndent()
-        val errors = ruleReturns.lint(code)
+        val errors = rule.lint(code)
         assertThat(errors).hasSize(1)
             .hasSourceLocations(
                 SourceLocation(2, 5)
@@ -89,7 +85,7 @@ class ComposeNamingCheckTest {
                 fun myComposable(): Unit { }
             """.trimIndent()
 
-        val errors = ruleNotReturns.lint(code)
+        val errors = rule.lint(code)
         assertThat(errors).hasSize(2)
             .hasSourceLocations(
                 SourceLocation(2, 5),


### PR DESCRIPTION
I made separate rules for detekt so we could use two different Issue types. The same Issue can be used with multiple error messages, so now I've done it more cohesive (and similar to ktlint rules) by using 1 combined Issue and two different error messages.