### PR TITLE
Updated documentation to include Detekt instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ Check out the project website for more information: https://twitter.github.io/co
 
 The comprehensive list of what these rules will check for is in [the rules documentaton](https://github.com/twitter/compose-rules/blob/main/docs/rules.md). It contains both what we check for and why are we doing that, so giving it a good read is encouraged.
 
-## Using the custom ruleset with ktlint
-
-### With ktlint-gradle
-
-If using [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle), you can specify the dependency on this set of rules by using the `ktlintRuleset`.
+## Using with ktlint
 
 ```groovy
 dependencies {
@@ -24,9 +20,21 @@ dependencies {
 }
 ```
 
-### With spotless
+For more information, you can refer to the [Using with ktlint](https://twitter.github.io/compose-rules/#using-the-custom-ruleset-with-ktlint) documentation.
 
-If using [Spotless](https://github.com/diffplug/spotless), there is currently a workaround on how to do that described [in this issue](https://github.com/diffplug/spotless/issues/1220).
+### Using with Spotless
+
+If using [Spotless](https://github.com/diffplug/spotless), you can use these rules via ktlint. There doesn't seem to be official support for this yet, but there is a workaround explained [in this issue](https://github.com/diffplug/spotless/issues/1220).
+
+## Using with Detekt
+
+```groovy
+dependencies {
+    detektPlugins "com.twitter.compose.rules:ktlint:<VERSION>"
+}
+```
+
+For more information, you can refer to the [Using with Detekt](https://twitter.github.io/compose-rules/#using-the-custom-ruleset-with-detekt) documentation.
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ dependencies {
 If using [Spotless](https://github.com/diffplug/spotless), there is currently a workaround on how to do that described [in this issue](https://github.com/diffplug/spotless/issues/1220).
 
 
-## Disabling a specific rule
+### Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.
 
@@ -35,4 +35,26 @@ For example, to disable `compose-naming-check`, the tag you'll need to disable i
     /* ktlint-disable twitter-compose:compose-naming-check */
     ... your code here
     /* ktlint-enable twitter-compose:compose-naming-check */
+```
+
+## Using the custom ruleset with Detekt
+
+When using the [Detekt Gradle Plugin](https://detekt.dev/docs/gettingstarted/gradle), you can specify the dependency on this set of rules by using `detektPlugins`.
+
+```groovy
+dependencies {
+    detektPlugins "com.twitter.compose.rules:detekt:<VERSION>"
+}
+```
+
+### Disabling a specific rule
+
+To disable a rule you have to follow the [instructions from the Detekt documentation](https://detekt.dev/docs/introduction/suppressing-rules), and use the id of the rule you want to disable.
+
+For example, to disable `compose-naming-check`:
+
+```kotlin
+@Suppress("compose-naming-check")
+@Composable
+fun myNameIsWrong() { }
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -129,7 +129,7 @@ Let's see it with an example.
 ```kotlin
 @Composable
 private fun MyComposable() {
-    val viewModel = weaverViewModel<MyViewModel>()
+    val viewModel = viewModel<MyViewModel>()
     // ...
 }
 ```


### PR DESCRIPTION
I added some instructions on how to use the rules with Detekt, and removed docs duplication between the README (which now will contain the basics) and the actual documentation (which contains more info, and how to suppress rules).