### PR TITLE
Fix ComposeModifierComposable.kt which incorrectly reported a violati…

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierComposable.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierComposable.kt
@@ -11,7 +11,7 @@ class ComposeModifierComposable : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
         val receiverTypeReference = function.receiverTypeReference
-        if (receiverTypeReference != null && receiverTypeReference.text != "Modifier") return
+        if (receiverTypeReference == null || receiverTypeReference.text != "Modifier") return
 
         emitter.report(function, ComposableModifier)
     }

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierComposableCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierComposableCheckTest.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class ComposeModifierComposableCheckTest {
@@ -27,5 +28,17 @@ class ComposeModifierComposableCheckTest {
         assertThat(errors).hasTextLocations("something1", "something2")
         assertThat(errors[0]).hasMessage(ComposeModifierComposable.ComposableModifier)
         assertThat(errors[1]).hasMessage(ComposeModifierComposable.ComposableModifier)
+    }
+
+    @Test
+    fun `Do not error on regular @Composable functions`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun MyComposable(text: String, modifier: Modifier = Modifier) {}
+        """.trimIndent()
+
+        val errors = rule.lint(code)
+        Assertions.assertTrue(errors.isEmpty())
     }
 }

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierComposableCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierComposableCheckTest.kt
@@ -36,4 +36,15 @@ class ComposeModifierComposableCheckTest {
             )
         )
     }
+
+    @Test
+    fun `Do not error on regular @Composable functions`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun MyComposable(text: String, modifier: Modifier = Modifier) {}
+        """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Small fix on ComposeModifierComposable which reported a violation on a regular Composable instead on only Modifier extension functions (I think this is an error). Added a unit test to verify the behavior.