### PR TITLE
Make the namings consistent for Detekt

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ dependencies {
 }
 ```
 
+NOTE: Currently [there seems to be an issue supporting ktlint over 0.46.0](https://github.com/JLLeitschuh/ktlint-gradle/pull/595).
+
 ### With spotless
 
 If using [Spotless](https://github.com/diffplug/spotless), there is currently a workaround on how to do that described [in this issue](https://github.com/diffplug/spotless/issues/1220).
@@ -47,14 +49,46 @@ dependencies {
 }
 ```
 
+### Enabling rules
+
+For the rules to be picked up, you will need to enable them in your `detekt.yml` file.
+
+```yaml
+TwitterCompose:
+  ContentEmitterReturningValues:
+    active: true
+  ModifierComposable:
+    active: true
+  ModifierMissing:
+    active: true
+  ModifierReused:
+    active: true
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+  MutableParams:
+    active: true
+  ComposableNaming:
+    active: true
+  ComposableParamOrder:
+    active: true
+  RememberMissing:
+    active: true
+  ViewModelForwarding:
+    active: true
+  ViewModelInjection:
+    active: true
+```
+
 ### Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the Detekt documentation](https://detekt.dev/docs/introduction/suppressing-rules), and use the id of the rule you want to disable.
 
-For example, to disable `compose-naming-check`:
+For example, to disable `ComposableNaming`:
 
 ```kotlin
-@Suppress("compose-naming-check")
+@Suppress("ComposableNaming")
 @Composable
 fun myNameIsWrong() { }
 ```

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheck.kt
@@ -15,7 +15,7 @@ class ComposeContentEmitterReturningValuesCheck(config: Config) :
     ComposeKtVisitor by ComposeContentEmitterReturningValues() {
 
     override val issue: Issue = Issue(
-        id = "content-emitter-returning-values-check",
+        id = "ContentEmitterReturningValues",
         severity = Severity.Defect,
         description = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo,
         debt = Debt.TWENTY_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierComposableCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierComposableCheck.kt
@@ -14,7 +14,7 @@ class ComposeModifierComposableCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeModifierComposable() {
     override val issue: Issue = Issue(
-        id = "modifier-composable-check",
+        id = "ModifierComposable",
         severity = Severity.Performance,
         description = ComposeModifierComposable.ComposableModifier,
         debt = Debt.TEN_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierMissingCheck.kt
@@ -14,7 +14,7 @@ class ComposeModifierMissingCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeModifierMissing() {
     override val issue: Issue = Issue(
-        id = "modifier-missing-check",
+        id = "ModifierMissing",
         severity = Severity.Defect,
         description = ComposeModifierMissing.MissingModifierContentComposable,
         debt = Debt.TEN_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierReusedCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierReusedCheck.kt
@@ -14,7 +14,7 @@ class ComposeModifierReusedCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeModifierReused() {
     override val issue: Issue = Issue(
-        id = "modifier-reused-check",
+        id = "ModifierReused",
         severity = Severity.Defect,
         description = ComposeModifierReused.ModifierShouldBeUsedOnceOnly,
         debt = Debt.TWENTY_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
@@ -17,7 +17,7 @@ class ComposeModifierWithoutDefaultCheck(config: Config) :
     override val autoCorrect: Boolean = true
 
     override val issue: Issue = Issue(
-        id = "modifier-without-default-check",
+        id = "ModifierWithoutDefault",
         severity = Severity.CodeSmell,
         description = ComposeModifierWithoutDefault.MissingModifierDefaultParam,
         debt = Debt.FIVE_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheck.kt
@@ -15,7 +15,7 @@ class ComposeMultipleContentEmittersCheck(config: Config) :
     ComposeKtVisitor by ComposeMultipleContentEmitters() {
 
     override val issue: Issue = Issue(
-        id = "multiple-emitters-check",
+        id = "MultipleEmitters",
         severity = Severity.Defect,
         description = ComposeMultipleContentEmitters.MultipleContentEmittersDetected,
         debt = Debt.TWENTY_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeMutableParametersCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeMutableParametersCheck.kt
@@ -14,7 +14,7 @@ class ComposeMutableParametersCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeMutableParameters() {
     override val issue: Issue = Issue(
-        id = "mutable-params-check",
+        id = "MutableParams",
         severity = Severity.Defect,
         description = ComposeMutableParameters.MutableParameterInCompose,
         debt = Debt.TWENTY_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheck.kt
@@ -14,7 +14,7 @@ class ComposeNamingCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeNaming() {
     override val issue: Issue = Issue(
-        id = "naming-check",
+        id = "ComposableNaming",
         severity = Severity.CodeSmell,
         description = """
         Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeParameterOrderCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeParameterOrderCheck.kt
@@ -14,7 +14,7 @@ class ComposeParameterOrderCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeParameterOrder() {
     override val issue: Issue = Issue(
-        id = "param-order-check",
+        id = "ComposableParamOrder",
         severity = Severity.CodeSmell,
         description = "Parameters in a composable function should be ordered following this pattern: " +
             "params without defaults, modifiers, params with defaults and optionally, " +

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeRememberMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeRememberMissingCheck.kt
@@ -15,7 +15,7 @@ class ComposeRememberMissingCheck(config: Config) :
     ComposeKtVisitor by ComposeRememberMissing() {
 
     override val issue: Issue = Issue(
-        id = "remember-missing-check",
+        id = "RememberMissing",
         severity = Severity.Defect,
         description = """
             Using mutableStateOf/derivedStateOf in a @Composable function without it being inside of a remember function.

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelForwardingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelForwardingCheck.kt
@@ -14,7 +14,7 @@ class ComposeViewModelForwardingCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeViewModelForwarding() {
     override val issue: Issue = Issue(
-        id = "vm-forwarding-check",
+        id = "ViewModelForwarding",
         severity = Severity.CodeSmell,
         description = ComposeViewModelForwarding.AvoidViewModelForwarding,
         debt = Debt.TWENTY_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelInjectionCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelInjectionCheck.kt
@@ -15,7 +15,7 @@ class ComposeViewModelInjectionCheck(config: Config) :
     ComposeKtVisitor by ComposeViewModelInjection() {
 
     override val issue: Issue = Issue(
-        id = "vm-injection-check",
+        id = "ViewModelInjection",
         severity = Severity.CodeSmell,
         description = """
             Implicit dependencies of composables should be made explicit.

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
@@ -28,6 +28,6 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
     )
 
     private companion object {
-        const val CustomRuleSetId = "twitter-compose"
+        const val CustomRuleSetId = "TwitterCompose"
     }
 }


### PR DESCRIPTION
Detekt favors pascal case for names of rulesets and rules, and we were using the same names as the ktlint rules. This patch changes the name of the custom ruleset to `TwitterCompose`, and all the individual rules to `PascalCase`. 

I also added the list of all the individual rules to enable for `detekt.yml` ready for copypasta, just to make it easier for folks that want to use Detekt.