### PR TITLE
Add rule to make preview composables private if used only in previews

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KtAnnotateds.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KtAnnotateds.kt
@@ -9,3 +9,6 @@ val KtAnnotated.isComposable: Boolean
 
 val KtAnnotated.isPreview: Boolean
     get() = annotationEntries.any { it.calleeExpression?.text == "Preview" }
+
+val KtAnnotated.isPreviewParameter: Boolean
+    get() = annotationEntries.any { it.calleeExpression?.text == "PreviewParameter" }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -149,6 +149,12 @@ private fun MyComposable(
 
 Related rule: [twitter-compose:vm-injection-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt)
 
+### Preview composables should not be public
+
+When a composable function exists solely because it's a `@Preview`, it doesn't need to have public visibility because it won't be used in actual UI. To prevent folks from using it unknowingly, we should restrict its visibility to `private`.
+
+Related rule: [twitter-compose:preview-public-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposePreviewPublic.kt)
+
 ## Modifiers
 
 ### When should I expose modifier parameters?

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposePreviewPublic.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposePreviewPublic.kt
@@ -1,0 +1,33 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules
+
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.Emitter
+import com.twitter.rules.core.util.isPreview
+import com.twitter.rules.core.util.isPreviewParameter
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposePreviewPublic : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        // We only want previews
+        if (!function.isPreview) return
+        // ...that have provided params to them (so we know they are only for previews)
+        if (function.valueParameters.none { it.isPreviewParameter }) return
+
+        emitter.report(function, ComposablesPreviewShouldNotBePublic, true)
+        if (autoCorrect) {
+            function.addModifier(KtTokens.PRIVATE_KEYWORD)
+        }
+    }
+
+    companion object {
+        val ComposablesPreviewShouldNotBePublic = """
+            Composables annotated with @Preview that are used only for previewing the UI should not be public.
+
+            See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposePreviewPublicCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposePreviewPublicCheck.kt
@@ -1,0 +1,25 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.compose.rules.ComposePreviewPublic
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.detekt.TwitterDetektRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+
+class ComposePreviewPublicCheck(config: Config) :
+    TwitterDetektRule(config),
+    ComposeKtVisitor by ComposePreviewPublic() {
+
+    override val autoCorrect: Boolean = true
+
+    override val issue: Issue = Issue(
+        id = "PreviewPublic",
+        severity = Severity.CodeSmell,
+        description = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic,
+        debt = Debt.FIVE_MINS
+    )
+}

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
@@ -21,6 +21,7 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
             ComposeMutableParametersCheck(config),
             ComposeNamingCheck(config),
             ComposeParameterOrderCheck(config),
+            ComposePreviewPublicCheck(config),
             ComposeRememberMissingCheck(config),
             ComposeViewModelForwardingCheck(config),
             ComposeViewModelInjectionCheck(config)

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.twitter.compose.rules.ComposePreviewPublic
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.ktlint.TwitterKtlintRule
+
+class ComposePreviewPublicCheck :
+    TwitterKtlintRule("twitter-compose:preview-public-check"),
+    ComposeKtVisitor by ComposePreviewPublic()

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/TwitterComposeRuleSetProvider.kt
@@ -29,6 +29,7 @@ class TwitterComposeRuleSetProvider :
         ComposeMutableParametersCheck(),
         ComposeNamingCheck(),
         ComposeParameterOrderCheck(),
+        ComposePreviewPublicCheck(),
         ComposeRememberMissingCheck(),
         ComposeViewModelForwardingCheck(),
         ComposeViewModelInjectionCheck()
@@ -45,6 +46,7 @@ class TwitterComposeRuleSetProvider :
         RuleProvider { ComposeMutableParametersCheck() },
         RuleProvider { ComposeNamingCheck() },
         RuleProvider { ComposeParameterOrderCheck() },
+        RuleProvider { ComposePreviewPublicCheck() },
         RuleProvider { ComposeRememberMissingCheck() },
         RuleProvider { ComposeViewModelForwardingCheck() }
     )

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
@@ -1,0 +1,73 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.twitter.compose.rules.ComposePreviewPublic
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposePreviewPublicCheckTest {
+
+    private val ruleAssertThat = assertThatRule { ComposePreviewPublicCheck() }
+
+    @Test
+    fun `passes for non-preview public composables`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun MyComposable() { }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes for preview public composables that don't have preview params`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun MyComposable() { }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when a public preview composable uses preview params`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun MyComposable(@PreviewParameter(User::class) user: User) {
+            }
+            """.trimIndent()
+        ruleAssertThat(code).hasLintViolation(
+            line = 3,
+            col = 5,
+            detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic
+        )
+    }
+
+    @Test
+    fun `autofix makes private the public preview`() {
+        @Language("kotlin")
+        val badCode = """
+            @Preview
+            @Composable
+            fun MyComposable(@PreviewParameter(User::class) user: User) {
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val expectedCode = """
+            @Preview
+            @Composable
+            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            }
+        """.trimIndent()
+        ruleAssertThat(badCode).isFormattedAs(expectedCode)
+    }
+}


### PR DESCRIPTION
If the `@Preview`ed rule is using `@PreviewParameter` we assume it's only going to be used for previewing, so we prompt for it to be made private.