### PR TITLE
Support hiltViewModel in the detectors for ViewModelInjection

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
@@ -103,7 +103,7 @@ class ComposeViewModelInjection : ComposeKtVisitor {
 
     companion object {
 
-        val KnownViewModelFactories by lazy { setOf("viewModel", "weaverViewModel") }
+        val KnownViewModelFactories by lazy { setOf("viewModel", "weaverViewModel", "hiltViewModel") }
 
         fun errorMessage(factoryName: String) = """
             Implicit dependencies of composables should be made explicit.

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelInjectionCheckTest.kt
@@ -16,7 +16,7 @@ class ComposeViewModelInjectionCheckTest {
     private val rule = ComposeViewModelInjectionCheck(Config.empty)
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `passes when a weaverViewModel is used as a default param`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -33,7 +33,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `overridden functions are ignored`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -48,7 +48,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -79,7 +79,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeViewModelInjectionCheckTest.kt
@@ -14,7 +14,7 @@ class ComposeViewModelInjectionCheckTest {
     private val injectionRuleAssertThat = assertThatRule { ComposeViewModelInjectionCheck() }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `passes when a weaverViewModel is used as a default param`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -30,7 +30,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `overridden functions are ignored`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -44,7 +44,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -82,7 +82,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -111,7 +111,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `fix no args composable function adds the code inside the parentheses`(viewModel: String) {
         @Language("kotlin")
         val badCode = """
@@ -139,7 +139,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `fix normal args composable function adds the new code at the end`(viewModel: String) {
         @Language("kotlin")
         val badCode = """
@@ -166,7 +166,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel"])
     fun `fix trailing lambda args composable function adds the new code before the trailing lambda`(viewModel: String) {
         @Language("kotlin")
         val badCode = """


### PR DESCRIPTION
We are supporting `viewModel` and `weaverViewModel`. For hilt + navigation, there is a `hiltViewModel` (https://developer.android.com/reference/kotlin/androidx/hilt/navigation/compose/package-summary#hiltViewModel(androidx.lifecycle.ViewModelStoreOwner)), which we should support as well.