### PR TITLE
Prevent false positives when ViewModels are used as keys on Effects

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
@@ -29,6 +29,8 @@ class ComposeViewModelForwarding : ComposeKtVisitor {
         // a capital letter (so, most likely, composables).
         bodyBlock.findDirectChildrenByClass<KtCallExpression>()
             .filter { callExpression -> callExpression.calleeExpression?.text?.first()?.isUpperCase() ?: false }
+            // Avoid LaunchedEffect/DisposableEffect/etc that can use the VM as a key
+            .filter { callExpression -> callExpression.calleeExpression?.text?.endsWith("Effect") == false }
             .flatMap { callExpression ->
                 // Get VALUE_ARGUMENT that has a REFERENCE_EXPRESSION. This would map to `viewModel` in this example:
                 // MyComposable(viewModel, ...)
@@ -43,7 +45,6 @@ class ComposeViewModelForwarding : ComposeKtVisitor {
     }
 
     companion object {
-
         val AvoidViewModelForwarding = """
             Forwarding a ViewModel through multiple @Composable functions should be avoided. Consider using
             state hoisting.

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
@@ -74,4 +74,21 @@ class ComposeViewModelForwardingCheckTest {
         assertThat(errors).hasSize(1).hasSourceLocation(3, 5)
         assertThat(errors.first()).hasMessage(ComposeViewModelForwarding.AvoidViewModelForwarding)
     }
+
+    @Test
+    fun `allows the forwarding of ViewModels that are used as keys`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun Content() {
+                val viewModel = weaverViewModel<MyVM>()
+                key(viewModel) { }
+                val x = remember(viewModel) { "ABC" }
+                LaunchedEffect(viewModel) { }
+            }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
@@ -74,4 +74,20 @@ class ComposeViewModelForwardingCheckTest {
             )
         )
     }
+
+    @Test
+    fun `allows the forwarding of ViewModels that are used as keys`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun Content() {
+                val viewModel = weaverViewModel<MyVM>()
+                key(viewModel) { }
+                val x = remember(viewModel) { "ABC" }
+                LaunchedEffect(viewModel) { }
+            }
+            """.trimIndent()
+        forwardingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Fixes #47

This patch adds an exception to the `ComposeViewModelForwarding` rule when using ViewModels as keys in LaunchedEffect, DisposableEffect, etc, which should be completely fine and common.