### PR TITLE
Added shadowJar to be able to create farjars for ktlint/detekt rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,7 @@ subprojects {
     spotless {
         kotlin {
             target "**/*.kt"
-            // ktlint 0.47.1 currently not supported - https://github.com/diffplug/spotless/pull/1303
-            // ktlint(libs.versions.ktlint.get())
-            ktlint("0.46.1")
+            ktlint(libs.versions.ktlint.get())
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,4 +23,5 @@ junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref
 assertj = "org.assertj:assertj-core:3.23.1"
 
 [plugins]
-spotless = { id = "com.diffplug.spotless", version = "6.10.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.11.0" }
+shadowJar = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }

--- a/rules/detekt/build.gradle
+++ b/rules/detekt/build.gradle
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.shadowJar)
 }
 apply plugin: "com.vanniktech.maven.publish"
 
@@ -10,11 +11,11 @@ test {
 }
 
 dependencies {
-    api project(':rules:common')
     api libs.detekt.core
+    api project(':rules:common')
+    api project(':core-detekt')
 
     implementation project(':core-common')
-    implementation project(':core-detekt')
 
     testImplementation libs.detekt.test
     testImplementation libs.junit5

--- a/rules/ktlint/build.gradle
+++ b/rules/ktlint/build.gradle
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.shadowJar)
 }
+
 apply plugin: "com.vanniktech.maven.publish"
 
 test {
@@ -10,11 +12,11 @@ test {
 }
 
 dependencies {
-    api project(':rules:common')
     api libs.ktlint.core
+    api project(':rules:common')
+    api project(':core-ktlint')
 
     implementation project(':core-common')
-    implementation project(':core-ktlint')
 
     testImplementation libs.ktlint.test
     testImplementation libs.junit5


### PR DESCRIPTION
Using `shadowJar`, we can now generate fat jars (that contain all the dependencies necessary in them) for both `:rules:ktlint` and `:rules:detekt`. This is important to be able to run the rules via CLI in both of them.

Tested locally for both CLIs and worked fine. Folks, remember to have a detekt.yml allowlisting all the rules, like described in the docs :smile:

This partially addresses #50 , however we'll still need to publish these fat jars as release notes, which will require CI changes.