### PR TITLE
Add more elements to trigger the known mutable types check

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
@@ -5,11 +5,10 @@ package com.twitter.rules.core.util
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T =
     if (value) block() else this
 
-fun String?.matchesAnyOf(patterns: Collection<Regex>): Boolean {
-    if (!isNullOrEmpty()) {
-        patterns.forEach { regex ->
-            if (matches(regex)) return true
-        }
+fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
+    if (isNullOrEmpty()) return false
+    for (regex in patterns) {
+        if (matches(regex)) return true
     }
     return false
 }

--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
@@ -7,29 +7,35 @@ import org.jetbrains.kotlin.psi.KtParameter
 val KtParameter.isTypeMutable: Boolean
     get() = typeReference?.text?.matchesAnyOf(KnownMutableCommonTypes) == true
 
-private val KnownMutableCommonTypes by lazy {
-    listOf(
-        // Set
-        "MutableSet<.*>\\??",
-        "ArraySet<.*>\\??",
-        "HashSet<.*>\\??",
-        // List
-        "MutableList<.*>\\??",
-        "ArrayList<.*>\\??",
-        // Array
-        "SparseArray<.*>\\??",
-        "SparseArrayCompat<.*>\\??",
-        "LongSparseArray<.*>\\??",
-        "SparseBooleanArray\\??",
-        "SparseIntArray\\??",
-        // Map
-        "MutableMap<.*>\\??",
-        "HashMap<.*>\\??",
-        "Hashtable<.*>\\??",
-        // Compose
-        "MutableState<.*>\\??",
-        // Flow
-        "MutableStateFlow<.*>\\??",
-        "MutableSharedFlow<.*>\\??"
-    ).map { Regex(it) }
-}
+private val KnownMutableCommonTypes = sequenceOf(
+    // Set
+    "MutableSet<.*>\\??",
+    "ArraySet<.*>\\??",
+    "HashSet<.*>\\??",
+    // List
+    "MutableList<.*>\\??",
+    "ArrayList<.*>\\??",
+    // Array
+    "SparseArray<.*>\\??",
+    "SparseArrayCompat<.*>\\??",
+    "LongSparseArray<.*>\\??",
+    "SparseBooleanArray\\??",
+    "SparseIntArray\\??",
+    // Map
+    "MutableMap<.*>\\??",
+    "HashMap<.*>\\??",
+    "Hashtable<.*>\\??",
+    // Compose
+    "MutableState<.*>\\??",
+    "SnapshotStateList<.*>\\??",
+    // Flow
+    "MutableStateFlow<.*>\\??",
+    "MutableSharedFlow<.*>\\??",
+    // RxJava & RxRelay
+    "PublishSubject<.*>\\??",
+    "BehaviorSubject<.*>\\??",
+    "ReplaySubject<.*>\\??",
+    "PublishRelay<.*>\\??",
+    "BehaviorRelay<.*>\\??",
+    "ReplayRelay<.*>\\??",
+).map { Regex(it) }

--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KtParameters.kt
@@ -37,5 +37,5 @@ private val KnownMutableCommonTypes = sequenceOf(
     "ReplaySubject<.*>\\??",
     "PublishRelay<.*>\\??",
     "BehaviorRelay<.*>\\??",
-    "ReplayRelay<.*>\\??",
+    "ReplayRelay<.*>\\??"
 ).map { Regex(it) }


### PR DESCRIPTION
I am adding rxjava/rxrelay subjects (yes, I've seen these being passed down to a composable :grimacing:) and `SnapshotStateList` to the denylist.