### PR TITLE
Update docs with ktlint/detekt instructions and new uber jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,11 @@ There are 2 ways you can add these static checks to your build - using ktlint or
 
 ## Using with ktlint
 
-```groovy
-dependencies {
-    ktlintRuleset "com.twitter.compose.rules:ktlint:<VERSION>"
-}
-```
-
-For more information, you can refer to the [Using with ktlint](https://twitter.github.io/compose-rules/#using-the-custom-ruleset-with-ktlint) documentation.
+You can refer to the [Using with ktlint](https://twitter.github.io/compose-rules/ktlint) documentation.
 
 ## Using with Detekt
 
-```groovy
-dependencies {
-    detektPlugins "com.twitter.compose.rules:detekt:<VERSION>"
-}
-```
-
-For more information, you can refer to the [Using with Detekt](https://twitter.github.io/compose-rules/#using-the-custom-ruleset-with-detekt) documentation.
+You can refer to the [Using with Detekt](https://twitter.github.io/compose-rules/detekt) documentation.
 
 ## Contributing
 

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -1,0 +1,61 @@
+When using the [Detekt Gradle Plugin](https://detekt.dev/docs/gettingstarted/gradle), you can specify the dependency on this set of rules by using `detektPlugins`.
+
+```groovy
+dependencies {
+    detektPlugins "com.twitter.compose.rules:detekt:<VERSION>"
+}
+```
+
+### Using with detekt CLI
+
+The [releases](https://github.com/twitter/compose-rules/releases) page contains an [uber jar](https://stackoverflow.com/questions/11947037/what-is-an-uber-jar) for each version release that can be used to run with the [CLI version of detekt](https://detekt.dev/docs/gettingstarted/cli).
+
+```shell
+detekt -p detekt-<VERSION>-all.jar -c your/config/detekt.yml
+```
+
+### Enabling rules
+
+For the rules to be picked up, you will need to enable them in your `detekt.yml` configuration file.
+
+```yaml
+TwitterCompose:
+  ContentEmitterReturningValues:
+    active: true
+  ModifierComposable:
+    active: true
+  ModifierMissing:
+    active: true
+  ModifierReused:
+    active: true
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+  MutableParams:
+    active: true
+  ComposableNaming:
+    active: true
+  ComposableParamOrder:
+    active: true
+  PreviewPublic:
+    active: true
+  RememberMissing:
+    active: true
+  ViewModelForwarding:
+    active: true
+  ViewModelInjection:
+    active: true
+```
+
+### Disabling a specific rule
+
+To disable a rule you have to follow the [instructions from the Detekt documentation](https://detekt.dev/docs/introduction/suppressing-rules), and use the id of the rule you want to disable.
+
+For example, to disable `ComposableNaming`:
+
+```kotlin
+@Suppress("ComposableNaming")
+@Composable
+fun myNameIsWrong() { }
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,96 +1,16 @@
 Twitter Compose Rules is a set of custom ktlint rules to ensure that your composables don't fall into common pitfalls, that might be easy to miss in code reviews.
 
 ## Why
+It can be challenging for big teams to start adopting Compose, particularly because not everyone will start at same time or with the same patterns. Twitter tried to ease the pain by creating a set of Compose static checks.
 
-A big challenge to face when a big team with a large codebase starts adopting Compose is that not everybody will start at the same page. This happened to us at Twitter.
+Compose has lots of superpowers but also has a bunch of footguns to be aware of [as seen in this Twitter Thread](https://twitter.com/mrmans0n/status/1507390768796909571).
 
-Compose is 🔝, allows for amazing things, but has a bunch of footguns to be aware of. [See the thread](https://twitter.com/mrmans0n/status/1507390768796909571).
+This is where our static checks come in. We want to detect as many potential issues as we can, as quickly as we can. In this case we want an error to show prior to engineers having to review code. Similar to other static check libraries we hope this leads to a "don't shoot the messengers" philosphy which will foster healthy Compose adoption.
 
-This is where these static checks come in. We want to detect all the potential issues even before they reach the code review state, and foster a healthy Compose adoption.
+## Using with ktlint
 
-## Using the custom ruleset with ktlint
+You can refer to the [Using with ktlint](https://twitter.github.io/compose-rules/ktlint) documentation.
 
-### With ktlint-gradle
+## Using with Detekt
 
-If using [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle), you can specify the dependency on this set of rules by using the `ktlintRuleset`.
-
-```groovy
-dependencies {
-    ktlintRuleset "com.twitter.compose.rules:ktlint:<VERSION>"
-}
-```
-
-NOTE: Currently [there seems to be an issue supporting ktlint over 0.46.0](https://github.com/JLLeitschuh/ktlint-gradle/pull/595).
-
-### With spotless
-
-If using [Spotless](https://github.com/diffplug/spotless), there is currently a workaround on how to do that described [in this issue](https://github.com/diffplug/spotless/issues/1220).
-
-
-### Disabling a specific rule
-
-To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.
-
-For example, to disable `compose-naming-check`, the tag you'll need to disable is `twitter-compose:compose-naming-check`.
-
-```kotlin
-    /* ktlint-disable twitter-compose:compose-naming-check */
-    ... your code here
-    /* ktlint-enable twitter-compose:compose-naming-check */
-```
-
-## Using the custom ruleset with Detekt
-
-When using the [Detekt Gradle Plugin](https://detekt.dev/docs/gettingstarted/gradle), you can specify the dependency on this set of rules by using `detektPlugins`.
-
-```groovy
-dependencies {
-    detektPlugins "com.twitter.compose.rules:detekt:<VERSION>"
-}
-```
-
-### Enabling rules
-
-For the rules to be picked up, you will need to enable them in your `detekt.yml` file.
-
-```yaml
-TwitterCompose:
-  ContentEmitterReturningValues:
-    active: true
-  ModifierComposable:
-    active: true
-  ModifierMissing:
-    active: true
-  ModifierReused:
-    active: true
-  ModifierWithoutDefault:
-    active: true
-  MultipleEmitters:
-    active: true
-  MutableParams:
-    active: true
-  ComposableNaming:
-    active: true
-  ComposableParamOrder:
-    active: true
-  PreviewPublic:
-    active: true
-  RememberMissing:
-    active: true
-  ViewModelForwarding:
-    active: true
-  ViewModelInjection:
-    active: true
-```
-
-### Disabling a specific rule
-
-To disable a rule you have to follow the [instructions from the Detekt documentation](https://detekt.dev/docs/introduction/suppressing-rules), and use the id of the rule you want to disable.
-
-For example, to disable `ComposableNaming`:
-
-```kotlin
-@Suppress("ComposableNaming")
-@Composable
-fun myNameIsWrong() { }
-```
+You can refer to the [Using with Detekt](https://twitter.github.io/compose-rules/detekt) documentation.

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -1,0 +1,50 @@
+## Using with Kotlinter
+
+If using [kotlinter](https://github.com/jeremymailen/kotlinter-gradle), you can specify the dependency on this set of rules [by using the `buildscript` classpath](https://github.com/jeremymailen/kotlinter-gradle#custom-rules).
+
+```groovy
+buildscript {
+    dependencies {
+        classpath "com.twitter.compose.rules:ktlint:<version>"
+    }
+}
+```
+
+## Using with ktlint-gradle
+
+> **Warning**: This plugin doesn't currently support ktlint versions over 0.46.0, [they are working to support it right now](https://github.com/JLLeitschuh/ktlint-gradle/pull/595).
+
+If using [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle), you can specify the dependency on this set of rules by using the `ktlintRuleset`.
+
+```groovy
+dependencies {
+    ktlintRuleset "com.twitter.compose.rules:ktlint:<VERSION>"
+}
+```
+
+## Using with spotless
+
+> **Warning**: If using [Spotless](https://github.com/diffplug/spotless), there is [no current way of enabling a custom ruleset like ours](https://github.com/diffplug/spotless/issues/1220). You would need to use any of the alternatives listed here (like Kotlinter) to just run these rules.
+
+## Using with ktlint CLI or the ktlint (unofficial) IntelliJ plugin
+
+The [releases](https://github.com/twitter/compose-rules/releases) page contains an [uber jar](https://stackoverflow.com/questions/11947037/what-is-an-uber-jar) for each version release that can be used for these purposes.
+
+To use with [ktlint CLI](https://ktlint.github.io/#getting-started):
+```shell
+ktlint -R ktlint-<VERSION>-all.jar
+```
+
+You can use this same jar in the [ktlint (unofficial) IntelliJ plugin](https://plugins.jetbrains.com/plugin/15057-ktlint-unofficial-) if the rules are compiled against the same ktlint version used for that release. You can configure the custom ruleset in the preferences page of the plugin.
+
+## Disabling a specific rule
+
+To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.
+
+For example, to disable `compose-naming-check`, the tag you'll need to disable is `twitter-compose:compose-naming-check`.
+
+```kotlin
+    /* ktlint-disable twitter-compose:compose-naming-check */
+    ... your code here
+    /* ktlint-enable twitter-compose:compose-naming-check */
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,8 @@ repo_url: 'https://github.com/twitter/compose-rules'
 # Navigation
 nav:
     - 'Overview': index.md
+    - 'Ktlint': ktlint.md
+    - 'Detekt': detekt.md
     - 'Ruleset': rules.md
 
 # Configuration


### PR DESCRIPTION
Using the rules with ktlint is an adventure, and for now only kotlinter seems a valid option. I have kept the ktlint-gradle and spotless sections as a FAQ though. I've also added mentions to use the uber jars added to releases for ktlint/detekt CLI in the docs.

Given that the "Overview" section was getting a bit big, I've broken down in two separate pages for ktlint and detekt.

Supersedes #54 by adding extra info.