### PR TITLE
Don't publish shadowRuntimeElements variant unless it's an uber jar publication

### DIFF
--- a/.github/workflows/update-release.yaml
+++ b/.github/workflows/update-release.yaml
@@ -31,7 +31,7 @@ jobs:
 
           - name: Build the fat jars for CLI usage
             if: success() && !endsWith(env.VERSION, '-SNAPSHOT')
-            run: ./gradlew clean :rules:ktlint:shadowJar :rules:detekt:shadowJar --rerun-tasks
+            run: ./gradlew clean :rules:ktlint:shadowJar :rules:detekt:shadowJar -PuberJar --rerun-tasks
 
           - name: Upload ktlint binaries to release
             if: success() && !endsWith(env.VERSION, '-SNAPSHOT')

--- a/rules/detekt/build.gradle
+++ b/rules/detekt/build.gradle
@@ -10,6 +10,14 @@ test {
     useJUnitPlatform()
 }
 
+// if publishing and it's not the uber jar, we want to remove the shadowRuntimeElements variant
+if (!project.hasProperty("uberJar")) {
+    AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+    javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
+        skip()
+    }
+}
+
 dependencies {
     api libs.detekt.core
     api project(':rules:common')

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
@@ -13,9 +13,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 class ComposeModifierWithoutDefaultCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeModifierWithoutDefault() {
-
-    override val autoCorrect: Boolean = true
-
+    
     override val issue: Issue = Issue(
         id = "ModifierWithoutDefault",
         severity = Severity.CodeSmell,

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheck.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 class ComposeModifierWithoutDefaultCheck(config: Config) :
     TwitterDetektRule(config),
     ComposeKtVisitor by ComposeModifierWithoutDefault() {
-    
+
     override val issue: Issue = Issue(
         id = "ModifierWithoutDefault",
         severity = Severity.CodeSmell,

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
@@ -27,7 +27,7 @@ class ComposeModifierWithoutDefaultCheckTest {
         val errors = rule.lint(composableCode)
         assertThat(errors).hasSourceLocations(
             SourceLocation(2, 15),
-            SourceLocation(4, 57)
+            SourceLocation(4, 46)
         )
         assertThat(errors[0]).hasMessage(ComposeModifierWithoutDefault.MissingModifierDefaultParam)
         assertThat(errors[1]).hasMessage(ComposeModifierWithoutDefault.MissingModifierDefaultParam)

--- a/rules/ktlint/build.gradle
+++ b/rules/ktlint/build.gradle
@@ -4,11 +4,18 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     alias(libs.plugins.shadowJar)
 }
-
 apply plugin: "com.vanniktech.maven.publish"
 
 test {
     useJUnitPlatform()
+}
+
+// if publishing and it's not the uber jar, we want to remove the shadowRuntimeElements variant
+if (!project.hasProperty("uberJar")) {
+    AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+    javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
+        skip()
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Publishing `shadowRuntimeElements` variant can cause problems, so we will only be doing it when passing -PuberJar param to gradle. We'll disable this variant by default, and just enable it in CI in the update-release workflow.

Tested in:

- [x] ktlint-cli
- [x] detekt-cli
- [x] kotlinter
- [ ] detekt gradle

Will test the latter when I have a minute.

Fixes #71.