### PR TITLE
Make the :rules:common dependency to :core-common API

### DIFF
--- a/rules/common/build.gradle
+++ b/rules/common/build.gradle
@@ -10,7 +10,7 @@ test {
 }
 
 dependencies {
-    implementation project(':core-common')
+    api project(':core-common')
 
     testImplementation libs.junit5
     testImplementation libs.junit5.params


### PR DESCRIPTION
This is necessary to provide new wrappers for external consumers of this project. I need this for TfA, actually 😉 😉