### PR TITLE
Add customization for rules that check content emitters

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
@@ -1,0 +1,32 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+
+interface ComposeKtConfig {
+    fun getInt(key: String, default: Int): Int
+    fun getString(key: String, default: String?): String?
+    fun getList(key: String, default: List<String>): List<String>
+    fun getSet(key: String, default: Set<String>): Set<String>
+
+    companion object {
+        private val Key: Key<ComposeKtConfig> = Key("twitter_compose_rules_config")
+        private val ReturnDefaults = object : ComposeKtConfig {
+            override fun getInt(key: String, default: Int): Int = default
+            override fun getString(key: String, default: String?): String? = default
+            override fun getList(key: String, default: List<String>): List<String> = default
+            override fun getSet(key: String, default: Set<String>) = default
+        }
+
+        fun PsiElement.config(): ComposeKtConfig = containingFile.getUserData(Key) ?: ReturnDefaults
+
+        fun ASTNode.config(): ComposeKtConfig = psi.config()
+
+        fun PsiElement.attach(config: ComposeKtConfig) {
+            containingFile.putUserData(Key, config)
+        }
+    }
+}

--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
+import com.twitter.rules.core.ComposeKtConfig.Companion.config
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
@@ -13,8 +14,10 @@ val KtFunction.emitsContent: Boolean
 val KtCallExpression.emitsContent: Boolean
     get() {
         val methodName = calleeExpression?.text ?: return false
+        val providedContentEmitters = config().getSet("contentEmitters", emptySet())
         return ComposableEmittersList.contains(methodName) ||
             ComposableEmittersListRegex.matches(methodName) ||
+            providedContentEmitters.contains(methodName) ||
             containsComposablesWithModifiers
     }
 

--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KotlinUtils.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.util
 
+import java.util.Locale
+
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T =
     if (value) block() else this
 
@@ -12,3 +14,14 @@ fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
     }
     return false
 }
+
+fun String.toCamelCase() = split('_').joinToString(
+    separator = "",
+    transform = { original ->
+        original.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+    }
+)
+
+fun String.toSnakeCase() = replace(humps, "_").lowercase(Locale.getDefault())
+
+private val humps by lazy(LazyThreadSafetyMode.NONE) { "(?<=.)(?=\\p{Upper})".toRegex() }

--- a/core-detekt/build.gradle
+++ b/core-detekt/build.gradle
@@ -4,7 +4,16 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply plugin: "com.vanniktech.maven.publish"
+
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     api libs.detekt.core
     implementation project(':core-common')
+
+    testImplementation libs.detekt.test
+    testImplementation libs.junit5
+    testImplementation libs.assertj
 }

--- a/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfig.kt
+++ b/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfig.kt
@@ -1,0 +1,39 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core.detekt
+
+import com.twitter.rules.core.ComposeKtConfig
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+
+/**
+ * Manages the configuration for detekt rules. Results will be memoized, as config shouldn't be changing
+ * during the lifetime of a rule.
+ */
+internal class DetektComposeKtConfig(
+    private val config: Config
+) : ComposeKtConfig {
+    private val cache = mutableMapOf<String, Any?>()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> valueOrPut(key: String, value: () -> T?): T? =
+        cache.getOrPut(key) { value() } as? T
+
+    override fun getInt(key: String, default: Int): Int =
+        valueOrPut(key) { config.valueOrDefault(key, default) } ?: default
+
+    override fun getString(key: String, default: String?): String? =
+        valueOrPut(key) {
+            if (default == null) {
+                config.valueOrNull(key)
+            } else {
+                config.valueOrDefault(key, default)
+            }
+        }
+
+    override fun getList(key: String, default: List<String>): List<String> =
+        valueOrPut(key) { config.valueOrDefaultCommaSeparated(key, default) } ?: default
+
+    override fun getSet(key: String, default: Set<String>): Set<String> =
+        valueOrPut(key) { getList(key, default.toList()).toSet() } ?: default
+}

--- a/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
+++ b/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.rules.core.detekt
 
+import com.twitter.rules.core.ComposeKtConfig
+import com.twitter.rules.core.ComposeKtConfig.Companion.attach
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.util.isComposable
@@ -23,6 +25,8 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 abstract class TwitterDetektRule(
     config: Config = Config.empty
 ) : Rule(config), ComposeKtVisitor {
+
+    private val config: ComposeKtConfig = DetektComposeKtConfig(config)
 
     private val emitter: Emitter = Emitter { element, message, canBeAutoCorrected ->
         // Grab the named element if there were any, otherwise fall back to the whole PsiElement
@@ -48,6 +52,7 @@ abstract class TwitterDetektRule(
 
     override fun visit(root: KtFile) {
         super.visit(root)
+        root.attach(config)
         visitFile(root, autoCorrect, emitter)
     }
 

--- a/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
+++ b/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
@@ -1,0 +1,72 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core.detekt
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class DetektComposeKtConfigTest {
+
+    private val mapping = mutableMapOf<String, Any>().apply {
+        put("myInt", 10)
+        put("myString", "abcd")
+        put("myList", "a,b,c,a")
+        put("myList2", "a , b , c,a")
+        put("mySet", "a,b,c,a,b,c")
+        put("mySet2", "  a, b,c ,a  , b  ,  c ")
+    }
+    private val detektConfig = TestConfig(mapping)
+    private val config = DetektComposeKtConfig(detektConfig)
+
+    @Test
+    fun `returns ints from Config, and default values when unset`() {
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getInt("myOtherInt", 0)).isEqualTo(0)
+    }
+
+    @Test
+    fun `returns strings from Config, and default values when unset`() {
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getString("myOtherString", "ABCD")).isEqualTo("ABCD")
+        assertThat(config.getString("myOtherStringWithNullDefault", null)).isNull()
+    }
+
+    @Test
+    fun `returns lists from Config, and default values when unset`() {
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myOtherList", listOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `returns sets from Config, and default values when unset`() {
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("myOtherSet", setOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `results are memoized`() {
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+
+        mapping["myInt"] = 100
+        mapping["myString"] = "XYZ"
+        mapping["myList"] = "z,y,x"
+        mapping["myList2"] = "z,y"
+        mapping["mySet"] = "a"
+        mapping["mySet2"] = "a, b"
+
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+    }
+}

--- a/core-ktlint/build.gradle
+++ b/core-ktlint/build.gradle
@@ -4,7 +4,16 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply plugin: "com.vanniktech.maven.publish"
+
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     api libs.ktlint.core
     implementation project(':core-common')
+
+    testImplementation libs.ktlint.test
+    testImplementation libs.junit5
+    testImplementation libs.assertj
 }

--- a/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/EditorConfigProperties.kt
+++ b/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/EditorConfigProperties.kt
@@ -1,0 +1,24 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core.ktlint
+
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
+import org.ec4j.core.model.PropertyType
+
+val contentEmittersProperty: UsesEditorConfigProperties.EditorConfigProperty<String> =
+    UsesEditorConfigProperties.EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "content_emitters",
+            "A comma separated list of composable functions that emit content (e.g. UI)",
+            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet()
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        }
+    )

--- a/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
+++ b/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
@@ -1,0 +1,37 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core.ktlint
+
+import com.pinterest.ktlint.core.api.EditorConfigProperties
+import com.twitter.rules.core.ComposeKtConfig
+import com.twitter.rules.core.util.toSnakeCase
+
+/**
+ * Manages the configuration for ktlint rules. In ktlint, configs are typically in snake case, while in the
+ * whole project and in detekt they are camel case, so this class will convert all camel case keys to snake case.
+ * Results will be memoized as well, as config shouldn't be changing during the lifetime of a rule.
+ */
+internal class KtlintComposeKtConfig(
+    private val properties: EditorConfigProperties
+) : ComposeKtConfig {
+    private val cache = mutableMapOf<String, Any?>()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> getValueAsOrPut(key: String, value: () -> T?): T? =
+        cache.getOrPut(key) { value() } as? T
+
+    override fun getInt(key: String, default: Int): Int =
+        getValueAsOrPut(key) { properties[key.toSnakeCase()]?.getValueAs<String>()?.toInt() } ?: default
+
+    override fun getString(key: String, default: String?): String? =
+        getValueAsOrPut(key) { properties[key.toSnakeCase()]?.getValueAs() } ?: default
+
+    override fun getList(key: String, default: List<String>): List<String> =
+        getValueAsOrPut(key) {
+            val original = properties[key.toSnakeCase()]?.getValueAs<String>() ?: return@getValueAsOrPut default
+            original.split(',', ';').map { it.trim() }
+        } ?: default
+
+    override fun getSet(key: String, default: Set<String>): Set<String> =
+        getValueAsOrPut(key) { getList(key, default.toList()).toSet() } ?: default
+}

--- a/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
+++ b/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
@@ -1,0 +1,76 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.rules.core.ktlint
+
+import com.pinterest.ktlint.core.api.EditorConfigProperties
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.ec4j.core.model.Property
+import org.junit.jupiter.api.Test
+
+class KtlintComposeKtConfigTest {
+    private val mapping = mutableMapOf<String, Property>().apply {
+        put("my_int", "10".prop)
+        put("my_string", "abcd".prop)
+        put("my_list", "a,b,c,a".prop)
+        put("my_list2", "a , b , c,a".prop)
+        put("my_set", "a,b,c,a,b,c".prop)
+        put("my_set2", "  a, b,c ,a  , b  ,  c ".prop)
+    }
+
+    private val properties: EditorConfigProperties = mapping
+    private val config = KtlintComposeKtConfig(properties)
+
+    @Test
+    fun `returns ints from properties, and default values when unset`() {
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getInt("myOtherInt", 0)).isEqualTo(0)
+    }
+
+    @Test
+    fun `returns strings from properties, and default values when unset`() {
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getString("myOtherString", "ABCD")).isEqualTo("ABCD")
+        assertThat(config.getString("myOtherStringWithNullDefault", null)).isNull()
+    }
+
+    @Test
+    fun `returns lists from properties, and default values when unset`() {
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myOtherList", listOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `returns sets from properties, and default values when unset`() {
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("myOtherSet", setOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `results are memoized`() {
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+
+        mapping["my_int"] = "100".prop
+        mapping["my_string"] = "XYZ".prop
+        mapping["my_list"] = "z,y,x".prop
+        mapping["my_list2"] = "z,y".prop
+        mapping["my_set"] = "a".prop
+        mapping["my_set2"] = "a, b".prop
+
+        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
+        assertThat(config.getString("myString", null)).isEqualTo("abcd")
+        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
+        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+    }
+
+    private val String.prop: Property
+        get() = Property.builder().value(this).build()
+}

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -22,6 +22,8 @@ For the rules to be picked up, you will need to enable them in your `detekt.yml`
 TwitterCompose:
   ContentEmitterReturningValues:
     active: true
+    # You can optionally add your own composables here
+    # contentEmitters: MyComposable,MyOtherComposable
   ModifierComposable:
     active: true
   ModifierMissing:
@@ -32,6 +34,8 @@ TwitterCompose:
     active: true
   MultipleEmitters:
     active: true
+      # You can optionally add your own composables here
+      # contentEmitters: MyComposable,MyOtherComposable
   MutableParams:
     active: true
   ComposableNaming:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -37,6 +37,17 @@ ktlint -R ktlint-twitter-compose-<VERSION>-all.jar
 
 You can use this same jar in the [ktlint (unofficial) IntelliJ plugin](https://plugins.jetbrains.com/plugin/15057-ktlint-unofficial-) if the rules are compiled against the same ktlint version used for that release. You can configure the custom ruleset in the preferences page of the plugin.
 
+## Configuring rules
+
+### Providing custom content emitters
+
+There are some rules (`twitter-compose:content-emitter-returning-values-check` and `twitter-compose:multiple-emitters-check`) that use predefined list of known composables that emit content. But you can add your own too! In your `.editorconfig` file, you'll need to add a `content_emitters` property followed by a list of composable names separated by commas. You would typically want the composables that are part of your custom design system to be in this list.
+
+```editorconfig
+[*.{kt,kts}]
+content_emitters = MyComposable,MyOtherComposable
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -52,6 +52,8 @@ More info: [Compose API guidelines](https://github.com/androidx/androidx/blob/an
 
 Related rule: [twitter-compose:content-emitter-returning-values-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeMultipleContentEmitters.kt)
 
+> **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
+
 ### Do not emit multiple pieces of content
 
 A composable function should emit either 0 or 1 pieces of layout, but no more. A composable function should be cohesive, and not rely on what function it is called from.
@@ -97,6 +99,8 @@ private fun ColumnScope.InnerContent() {
 This effectively ties the function to be called from a Column, but is still not recommended (although permitted).
 
 Related rule: [twitter-compose:multiple-emitters-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeMultipleContentEmitters.kt)
+
+> **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
 ### Naming @Composable functions properly
 

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheckTest.kt
@@ -3,8 +3,8 @@
 package com.twitter.compose.rules.detekt
 
 import com.twitter.compose.rules.ComposeContentEmitterReturningValues
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
@@ -12,7 +12,10 @@ import org.junit.jupiter.api.Test
 
 class ComposeContentEmitterReturningValuesCheckTest {
 
-    private val rule = ComposeContentEmitterReturningValuesCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "contentEmitters" to listOf("Potato", "Banana")
+    )
+    private val rule = ComposeContentEmitterReturningValuesCheck(testConfig)
 
     @Test
     fun `error out when detecting a content emitting composable that returns something other than unit`() {
@@ -33,12 +36,17 @@ class ComposeContentEmitterReturningValuesCheckTest {
                 fun Something3() { // This one is fine but calling it should make Something2 fail
                     HorizonIcon(icon = HorizonIcon.Arrow)
                 }
+                @Composable
+                fun Something4(): String { // This one is using a composable defined in the config
+                    Banana()
+                }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(2)
+        assertThat(errors)
             .hasSourceLocations(
                 SourceLocation(2, 5),
-                SourceLocation(7, 5)
+                SourceLocation(7, 5),
+                SourceLocation(16, 5)
             )
         for (error in errors) {
             assertThat(error).hasMessage(ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo)

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheckTest.kt
@@ -3,8 +3,8 @@
 package com.twitter.compose.rules.detekt
 
 import com.twitter.compose.rules.ComposeMultipleContentEmitters
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
@@ -12,7 +12,10 @@ import org.junit.jupiter.api.Test
 
 class ComposeMultipleContentEmittersCheckTest {
 
-    private val rule = ComposeMultipleContentEmittersCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "contentEmitters" to listOf("Potato", "Banana")
+    )
+    private val rule = ComposeMultipleContentEmittersCheck(testConfig)
 
     @Test
     fun `passes when only one item emits up at the top level`() {
@@ -97,11 +100,11 @@ class ComposeMultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun Something3() {
-                    Text("Hi")
+                    Potato()
                 }
                 @Composable
                 fun Something4() {
-                    Text("Alo")
+                    Banana()
                 }
                 @Composable
                 fun Something5() {

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeContentEmitterReturningValuesCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeContentEmitterReturningValuesCheckTest.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules.ktlint
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.twitter.compose.rules.ComposeContentEmitterReturningValues
+import com.twitter.rules.core.ktlint.contentEmittersProperty
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
@@ -31,18 +32,31 @@ class ComposeContentEmitterReturningValuesCheckTest {
                 fun Something3() { // This one is fine but calling it should make Something2 fail
                     HorizonIcon(icon = HorizonIcon.Arrow)
                 }
+                @Composable
+                fun Something4(): String { // This one is using a composable defined in the config
+                    Banana()
+                }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo
-            ),
-            LintViolation(
-                line = 7,
-                col = 5,
-                detail = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo
+        emittersRuleAssertThat(code)
+            .withEditorConfigOverride(
+                contentEmittersProperty to "Potato,Banana"
             )
-        )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 5,
+                    detail = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo
+                ),
+                LintViolation(
+                    line = 16,
+                    col = 5,
+                    detail = ComposeContentEmitterReturningValues.ContentEmitterReturningValuesToo
+                )
+            )
     }
 }

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeMultipleContentEmittersCheckTest.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules.ktlint
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.twitter.compose.rules.ComposeMultipleContentEmitters
+import com.twitter.rules.core.ktlint.contentEmittersProperty
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
@@ -100,7 +101,7 @@ class ComposeMultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun Something4() {
-                    Text("Alo")
+                    Banana()
                 }
                 @Composable
                 fun Something5() {
@@ -108,18 +109,22 @@ class ComposeMultipleContentEmittersCheckTest {
                     Something4()
                 }
             """.trimIndent()
-        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 6,
-                col = 5,
-                detail = ComposeMultipleContentEmitters.MultipleContentEmittersDetected
-            ),
-            LintViolation(
-                line = 19,
-                col = 5,
-                detail = ComposeMultipleContentEmitters.MultipleContentEmittersDetected
+        emittersRuleAssertThat(code)
+            .withEditorConfigOverride(
+                contentEmittersProperty to "Potato,Banana"
             )
-        )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 6,
+                    col = 5,
+                    detail = ComposeMultipleContentEmitters.MultipleContentEmittersDetected
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 5,
+                    detail = ComposeMultipleContentEmitters.MultipleContentEmittersDetected
+                )
+            )
     }
 
     @Test


### PR DESCRIPTION
Closes #40.

Introduces configuration to be able to add more content emitters (e.g. composables that emit content) to all checks that use it. Before this patch, it was [a hardcoded list](https://github.com/twitter/compose-rules/blob/main/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt#L29), and now they are configurable.

To make this work, I had to write a linter agnostic configuration system that would use ktlint's `.editorconfig` files / Detekt's `Config` class under the hood. Detekt rules (and our internal representation) use camel case naming, while ktlint rules use snake case -- for simplicity, the conversion is done automatically. The configs are also memoized per rule, to avoid performance issues. The config can be acquired from any PsiElement in the tree, as it's going to be stored in the UserData for `containingFile`.