### PR TITLE
Remove content emitters from Twitter's design system

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
@@ -93,26 +93,7 @@ private val ComposableEmittersList by lazy {
         "TopAppBarSurface",
         "VerticalPager",
         "VerticalPagerIndicator",
-        "WebView",
-        // Twitter Components
-        "AnnouncementOverlay",
-        "AttentionHorizonInlineCallout",
-        "DefaultHorizonInlineCallout",
-        "ErrorHorizonInlineCallout",
-        "Facepile",
-        "HorizonButton",
-        "HorizonIcon",
-        "HorizonInlineCallout",
-        "HorizonInlineCalloutCtaText",
-        "HorizonInlineCalloutIcon",
-        "HorizonInlineFeedback",
-        "HorizontalUserAttribution",
-        "HorizonTextInput",
-        "InfoItem",
-        "RichText",
-        "SuccessHorizonInlineCallout",
-        "TwitterFresco",
-        "UserImage"
+        "WebView"
     )
 }
 

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeContentEmitterReturningValuesCheckTest.kt
@@ -34,7 +34,7 @@ class ComposeContentEmitterReturningValuesCheckTest {
                 }
                 @Composable
                 fun Something3() { // This one is fine but calling it should make Something2 fail
-                    HorizonIcon(icon = HorizonIcon.Arrow)
+                    Potato(icon = HorizonIcon.Arrow)
                 }
                 @Composable
                 fun Something4(): String { // This one is using a composable defined in the config

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeContentEmitterReturningValuesCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeContentEmitterReturningValuesCheckTest.kt
@@ -30,7 +30,7 @@ class ComposeContentEmitterReturningValuesCheckTest {
                 }
                 @Composable
                 fun Something3() { // This one is fine but calling it should make Something2 fail
-                    HorizonIcon(icon = HorizonIcon.Arrow)
+                    Potato(icon = HorizonIcon.Arrow)
                 }
                 @Composable
                 fun Something4(): String { // This one is using a composable defined in the config


### PR DESCRIPTION
Now that they are configurable, we'll have TfA configure its own emitters. 