### PR TITLE
Add two missing ui emitters 

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
@@ -53,6 +53,8 @@ private val ComposableEmittersList by lazy {
         "Checkbox",
         "CircularProgressIndicator",
         "Divider",
+        "DropdownMenu",
+        "DropdownMenuItem",
         "ExposedDropdownMenuBox",
         "ExtendedFloatingActionButton",
         "FloatingActionButton",


### PR DESCRIPTION
While running this on TfA noticed that these two were missing. TBH there will probably more that we are missing, we just need to keep adding them as they pop up 😆 