### PR TITLE
Allow receivers in ComposeNaming rule

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.report
+import com.twitter.rules.core.util.hasReceiverType
 import com.twitter.rules.core.util.returnsValue
 import org.jetbrains.kotlin.psi.KtFunction
 
@@ -22,7 +23,8 @@ class ComposeNaming : ComposeKtVisitor {
             }
         } else {
             // If it returns Unit or doesn't have a return type, we should start with an uppercase letter
-            if (firstLetter.isLowerCase()) {
+            // If the composable has a receiver, we can ignore this.
+            if (firstLetter.isLowerCase() && !function.hasReceiverType) {
                 emitter.report(function, ComposablesThatDoNotReturnResultsShouldBeCapitalized)
             }
         }

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
@@ -95,4 +95,20 @@ class ComposeNamingCheckTest {
             assertThat(error).hasMessage(ComposeNaming.ComposablesThatDoNotReturnResultsShouldBeCapitalized)
         }
     }
+
+    @Test
+    fun `passes when a composable returns nothing or Unit and is lowercase but has a receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Potato.myComposable() { }
+
+                @Composable
+                fun Banana.myComposable(): Unit { }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeNamingCheckTest.kt
@@ -96,4 +96,19 @@ class ComposeNamingCheckTest {
             )
         )
     }
+
+    @Test
+    fun `passes when a composable returns nothing or Unit and is lowercase but has a receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Potato.myComposable() { }
+
+                @Composable
+                fun Banana.myComposable(): Unit { }
+            """.trimIndent()
+
+        namingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Ignore cases such as:
```
@Composable
fun MviViewModel<...>.onEffect(...) { }
```
to be flagged. 