### PR TITLE
Add ComposeCompositionLocalAllowlist rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -20,6 +20,10 @@ For the rules to be picked up, you will need to enable them in your `detekt.yml`
 
 ```yaml
 TwitterCompose:
+  CompositionLocalAllowlist:
+    active: true
+    # You can optionally define a list of CompositionLocals that are allowed here
+    # allowedCompositionLocals: LocalSomething,LocalSomethingElse
   ContentEmitterReturningValues:
     active: true
     # You can optionally add your own composables here

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -48,6 +48,15 @@ There are some rules (`twitter-compose:content-emitter-returning-values-check` a
 content_emitters = MyComposable,MyOtherComposable
 ```
 
+### Providing a list of allowed `CompositionLocal`s
+
+For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal`s that are allowed in your codebase.
+
+```editorconfig
+[*.{kt,kts}]
+allowed_composition_locals = LocalSomething,LocalSomethingElse
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -124,6 +124,8 @@ Related rule: [twitter-compose:param-order-check](https://github.com/twitter/com
 
 ### Make dependencies explicit
 
+#### ViewModels
+
 When designing our composables, we should always try to be explicit about the dependencies they take in. If you acquire a ViewModel or an instance from DI in the body of the composable, you are making this dependency implicit, which has the downsides of making it hard to test and harder to reuse.
 
 To solve this problem, you should inject these dependencies as default values in the composable function.
@@ -152,6 +154,16 @@ private fun MyComposable(
 ```
 
 Related rule: [twitter-compose:vm-injection-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt)
+
+#### `CompositionLocal`s
+
+`CompositionLocal` makes a composable's behavior harder to reason about. As they create implicit dependencies, callers of composables that use them need to make sure that a value for every CompositionLocal is satisfied.
+
+Although uncommon, there are [legit usecases](https://developer.android.com/jetpack/compose/compositionlocal#deciding) for them, so this rule provides an allowlist so that you can add your `CompositionLocal` names to it so that they are not flagged by the rule.
+
+Related rule: [twitter-compose:compositionlocal-allowlist](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/CompositionLocalAllowlist.kt)
+
+> **Note**: To add your custom `CompositionLocal` to your allowlist, you can add `allowedCompositionLocals` to this rule config in Detekt, or `allowed_composition_locals` to your .editorconfig in ktlint.
 
 ### Preview composables should not be public
 

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeCompositionLocalAllowlist.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeCompositionLocalAllowlist.kt
@@ -1,0 +1,37 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules
+
+import com.twitter.rules.core.ComposeKtConfig.Companion.config
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.Emitter
+import com.twitter.rules.core.report
+import com.twitter.rules.core.util.declaresCompositionLocal
+import com.twitter.rules.core.util.findChildrenByClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtProperty
+
+class ComposeCompositionLocalAllowlist : ComposeKtVisitor {
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+        val compositionLocals = file.findChildrenByClass<KtProperty>()
+            .filter { it.declaresCompositionLocal }
+
+        if (compositionLocals.none()) return
+
+        val allowed = file.config().getSet("allowedCompositionLocals", emptySet())
+        val notAllowed = compositionLocals.filterNot { allowed.contains(it.nameIdentifier?.text) }
+
+        for (compositionLocal in notAllowed) {
+            emitter.report(compositionLocal, CompositionLocalNotInAllowlist)
+        }
+    }
+
+    companion object {
+        val CompositionLocalNotInAllowlist = """
+            CompositionLocals are implicit dependencies and creating new ones should be avoided.
+
+            See https://twitter.github.io/compose-rules/rules/#make-dependencies-explicit for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.compose.rules.ComposeCompositionLocalAllowlist
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.detekt.TwitterDetektRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+
+class ComposeCompositionLocalAllowlistCheck(config: Config) :
+    TwitterDetektRule(config),
+    ComposeKtVisitor by ComposeCompositionLocalAllowlist() {
+
+    override val issue: Issue = Issue(
+        id = "CompositionLocalAllowlist",
+        severity = Severity.CodeSmell,
+        description = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+        debt = Debt.FIVE_MINS
+    )
+}

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheckTest.kt
@@ -1,0 +1,54 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.compose.rules.ComposeCompositionLocalAllowlist
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeCompositionLocalAllowlistCheckTest {
+
+    private val testConfig = TestConfig(
+        "allowedCompositionLocals" to listOf("LocalBanana", "LocalPotato")
+    )
+    private val rule = ComposeCompositionLocalAllowlistCheck(testConfig)
+
+    @Test
+    fun `error when a CompositionLocal is defined`() {
+        @Language("kotlin")
+        val code =
+            """
+                private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
+                internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
+                val LocalPrune = compositionLocalOf { "Prune" }
+                private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasSourceLocations(
+                SourceLocation(1, 13),
+                SourceLocation(2, 14),
+                SourceLocation(3, 5),
+                SourceLocation(4, 13)
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist)
+        }
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is defined but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Apple" }
+                val LocalPotato = compositionLocalOf { "Prune" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalAllowlistCheckTest.kt
@@ -45,8 +45,8 @@ class ComposeCompositionLocalAllowlistCheckTest {
         @Language("kotlin")
         val code =
             """
-                val LocalBanana = staticCompositionLocalOf<String> { "Apple" }
-                val LocalPotato = compositionLocalOf { "Prune" }
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.twitter.compose.rules.ComposeCompositionLocalAllowlist
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.ktlint.TwitterKtlintRule
+
+class ComposeCompositionLocalAllowlistCheck :
+    TwitterKtlintRule("twitter-compose:compositionlocal-allowlist"),
+    ComposeKtVisitor by ComposeCompositionLocalAllowlist()

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
@@ -22,3 +22,21 @@ val contentEmittersProperty: UsesEditorConfigProperties.EditorConfigProperty<Str
             }
         }
     )
+
+val compositionLocalAllowlistProperty: UsesEditorConfigProperties.EditorConfigProperty<String> =
+    UsesEditorConfigProperties.EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "allowed_composition_locals",
+            "A comma separated list of allowed CompositionLocals",
+            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet()
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        }
+    )

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import com.twitter.compose.rules.ComposeCompositionLocalAllowlist
+import com.twitter.rules.core.ktlint.compositionLocalAllowlistProperty
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeCompositionLocalAllowlistCheckTest {
+
+    private val allowlistRuleAssertThat = assertThatRule { ComposeCompositionLocalAllowlistCheck() }
+
+    @Test
+    fun `error when a CompositionLocal is defined`() {
+        @Language("kotlin")
+        val code =
+            """
+                private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
+                internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
+                val LocalPrune = compositionLocalOf { "Prune" }
+                private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+            """.trimIndent()
+        allowlistRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 1,
+                    col = 13,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist
+                ),
+                LintViolation(
+                    line = 2,
+                    col = 14,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist
+                ),
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 13,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist
+                )
+            )
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is defined but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Apple" }
+                val LocalPotato = compositionLocalOf { "Prune" }
+            """.trimIndent()
+        allowlistRuleAssertThat(code)
+            .withEditorConfigOverride(
+                compositionLocalAllowlistProperty to "LocalPotato,LocalBanana"
+            )
+            .hasNoLintViolations()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
@@ -53,8 +53,8 @@ class ComposeCompositionLocalAllowlistCheckTest {
         @Language("kotlin")
         val code =
             """
-                val LocalBanana = staticCompositionLocalOf<String> { "Apple" }
-                val LocalPotato = compositionLocalOf { "Prune" }
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
             """.trimIndent()
         allowlistRuleAssertThat(code)
             .withEditorConfigOverride(


### PR DESCRIPTION
Adds a rule to disallow the introduction of new `CompositionLocal`s, and adds a `allowedCompositionLocals` (Detekt) and `allowed_composition_locals` (ktlint) config entries to be able to provide an allowed list of them (e.g. if they are necessary for some infra or other valid cases like that, don't go abusing this 😅 ).