### PR TITLE
Add exemption for actual functions for ComposeModifierWithoutDefault

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
@@ -26,5 +26,11 @@ val KtFunction.isInternal: Boolean
 val KtFunction.isOverride: Boolean
     get() = hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
+val KtFunction.isActual: Boolean
+    get() = hasModifier(KtTokens.ACTUAL_KEYWORD)
+
+val KtFunction.isExpect: Boolean
+    get() = hasModifier(KtTokens.EXPECT_KEYWORD)
+
 val KtFunction.definedInInterface: Boolean
     get() = ((parent as? KtClassBody)?.parent as? KtClass)?.isInterface() ?: false

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierWithoutDefault.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierWithoutDefault.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.util.definedInInterface
+import com.twitter.rules.core.util.isActual
 import com.twitter.rules.core.util.isModifier
 import com.twitter.rules.core.util.lastChildLeafOrSelf
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -13,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 class ComposeModifierWithoutDefault : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
-        if (function.definedInInterface) return
+        if (function.definedInInterface || function.isActual) return
 
         // Look for modifier params in the composable signature, and if any without a default value is found, error out.
         function.valueParameters.filter { it.isModifier }

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
@@ -41,6 +41,8 @@ class ComposeModifierWithoutDefaultCheckTest {
                     @Composable
                     fun Something(modifier: Modifier)
                 }
+                @Composable
+                actual fun Something(modifier: Modifier) {}
         """.trimIndent()
 
         val errors = rule.lint(composableCode)

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierWithoutDefaultCheckTest.kt
@@ -53,6 +53,8 @@ class ComposeModifierWithoutDefaultCheckTest {
                     @Composable
                     fun Something(modifier: Modifier)
                 }
+                @Composable
+                actual fun Something(modifier: Modifier) {}
         """.trimIndent()
 
         modifierRuleAssertThat(composableCode).hasNoLintViolations()


### PR DESCRIPTION
`actual fun` should be exempt from needing a default value.

Fixes #81.