### PR TITLE
Add ComposeCompositionLocalNaming to validate CompositionLocal names

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -24,6 +24,8 @@ TwitterCompose:
     active: true
     # You can optionally define a list of CompositionLocals that are allowed here
     # allowedCompositionLocals: LocalSomething,LocalSomethingElse
+  CompositionLocalNaming:
+      active: true
   ContentEmitterReturningValues:
     active: true
     # You can optionally add your own composables here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,14 @@ Related rule: [twitter-compose:multiple-emitters-check](https://github.com/twitt
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
+### Naming CompositionLocals properly
+
+`CompositionLocal`s should be named by using the adjective `Local` as prefix, followed by a descriptive noun that describes the value they hold. This makes it easier to know when a value comes from a `CompositionLocal`. Given that these are implicit dependencies, we should make them obvious.
+
+More information: [Naming CompositionLocals](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#naming-compositionlocals)
+
+Related rule: [twitter-compose:compositionlocal-naming](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeCompositionLocalNaming.kt)
+
 ### Naming @Composable functions properly
 
 Composable functions that return `Unit` should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
@@ -110,7 +110,7 @@ class ComposeViewModelInjection : ComposeKtVisitor {
 
             Usages of $factoryName to acquire a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
 
-            See https://twitter.github.io/compose-rules/rules/#make-dependencies-explicit for more information.
+            See https://twitter.github.io/compose-rules/rules/#viewmodels for more information.
         """.trimIndent()
     }
 }

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheck.kt
@@ -15,7 +15,7 @@ class ComposeCompositionLocalNamingCheck(config: Config) :
     ComposeKtVisitor by ComposeCompositionLocalNaming() {
 
     override val issue: Issue = Issue(
-        id = "ComposeCompositionLocalNaming",
+        id = "CompositionLocalNaming",
         severity = Severity.CodeSmell,
         description = ComposeCompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
         debt = Debt.FIVE_MINS

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.compose.rules.ComposeCompositionLocalNaming
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.detekt.TwitterDetektRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+
+class ComposeCompositionLocalNamingCheck(config: Config) :
+    TwitterDetektRule(config),
+    ComposeKtVisitor by ComposeCompositionLocalNaming() {
+
+    override val issue: Issue = Issue(
+        id = "ComposeCompositionLocalNaming",
+        severity = Severity.CodeSmell,
+        description = ComposeCompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
+        debt = Debt.FIVE_MINS
+    )
+}

--- a/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProvider.kt
@@ -12,6 +12,8 @@ class TwitterComposeRuleSetProvider : RuleSetProvider {
     override fun instance(config: Config): RuleSet = RuleSet(
         CustomRuleSetId,
         listOf(
+            ComposeCompositionLocalAllowlistCheck(config),
+            ComposeCompositionLocalNamingCheck(config),
             ComposeContentEmitterReturningValuesCheck(config),
             ComposeModifierComposableCheck(config),
             ComposeModifierMissingCheck(config),

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeCompositionLocalNamingCheckTest.kt
@@ -1,0 +1,47 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.compose.rules.ComposeCompositionLocalNaming
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeCompositionLocalNamingCheckTest {
+
+    private val rule = ComposeCompositionLocalNamingCheck(Config.empty)
+
+    @Test
+    fun `error when a CompositionLocal has a wrong name`() {
+        @Language("kotlin")
+        val code =
+            """
+                val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
+                val Plum: String = staticCompositionLocalOf { "Plum" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasSourceLocations(
+                SourceLocation(1, 5),
+                SourceLocation(2, 5)
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposeCompositionLocalNaming.CompositionLocalNeedsLocalPrefix)
+        }
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is well named`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalNamingCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.twitter.compose.rules.ComposeCompositionLocalNaming
+import com.twitter.rules.core.ComposeKtVisitor
+import com.twitter.rules.core.ktlint.TwitterKtlintRule
+
+class ComposeCompositionLocalNamingCheck :
+    TwitterKtlintRule("twitter-compose:compositionlocal-naming"),
+    ComposeKtVisitor by ComposeCompositionLocalNaming()

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/TwitterComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/TwitterComposeRuleSetProvider.kt
@@ -20,6 +20,8 @@ class TwitterComposeRuleSetProvider :
     @Suppress("OVERRIDE_DEPRECATION")
     override fun get(): RuleSet = RuleSet(
         CustomRuleSetId,
+        ComposeCompositionLocalAllowlistCheck(),
+        ComposeCompositionLocalNamingCheck(),
         ComposeContentEmitterReturningValuesCheck(),
         ComposeModifierComposableCheck(),
         ComposeModifierMissingCheck(),
@@ -37,6 +39,8 @@ class TwitterComposeRuleSetProvider :
 
     // 0.47.0+ ruleset
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
+        RuleProvider { ComposeCompositionLocalAllowlistCheck() },
+        RuleProvider { ComposeCompositionLocalNamingCheck() },
         RuleProvider { ComposeContentEmitterReturningValuesCheck() },
         RuleProvider { ComposeModifierComposableCheck() },
         RuleProvider { ComposeModifierMissingCheck() },
@@ -48,7 +52,8 @@ class TwitterComposeRuleSetProvider :
         RuleProvider { ComposeParameterOrderCheck() },
         RuleProvider { ComposePreviewPublicCheck() },
         RuleProvider { ComposeRememberMissingCheck() },
-        RuleProvider { ComposeViewModelForwardingCheck() }
+        RuleProvider { ComposeViewModelForwardingCheck() },
+        RuleProvider { ComposeViewModelInjectionCheck() }
     )
 
     private companion object {

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeCompositionLocalNamingCheckTest.kt
@@ -1,0 +1,48 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import com.twitter.compose.rules.ComposeCompositionLocalNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeCompositionLocalNamingCheckTest {
+
+    private val ruleAssertThat = assertThatRule { ComposeCompositionLocalNamingCheck() }
+
+    @Test
+    fun `error when a CompositionLocal has a wrong name`() {
+        @Language("kotlin")
+        val code =
+            """
+                val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
+                val Plum: String = staticCompositionLocalOf { "Plum" }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 1,
+                    col = 5,
+                    detail = ComposeCompositionLocalNaming.CompositionLocalNeedsLocalPrefix
+                ),
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeCompositionLocalNaming.CompositionLocalNeedsLocalPrefix
+                )
+            )
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is well named`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
CompositionLocals should have the `Local` prefix (so that we know clearly they come from a composition local) as an adjective followed by a descriptive noun for the value they hold.