### PR TITLE
Filter restartable effects explicitly

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/Composables.kt
@@ -146,3 +146,15 @@ private val CompositionLocalReferenceExpressions by lazy(LazyThreadSafetyMode.NO
         "compositionLocalOf"
     )
 }
+
+val KtCallExpression.isRestartableEffect: Boolean
+    get() = RestartableEffects.contains(calleeExpression?.text)
+
+// From https://developer.android.com/jetpack/compose/side-effects#restarting-effects
+private val RestartableEffects by lazy(LazyThreadSafetyMode.NONE) {
+    setOf(
+        "LaunchedEffect",
+        "produceState",
+        "DisposableEffect"
+    )
+}

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
@@ -7,6 +7,7 @@ import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.util.definedInInterface
 import com.twitter.rules.core.util.findDirectChildrenByClass
 import com.twitter.rules.core.util.isOverride
+import com.twitter.rules.core.util.isRestartableEffect
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtReferenceExpression
@@ -30,7 +31,7 @@ class ComposeViewModelForwarding : ComposeKtVisitor {
         bodyBlock.findDirectChildrenByClass<KtCallExpression>()
             .filter { callExpression -> callExpression.calleeExpression?.text?.first()?.isUpperCase() ?: false }
             // Avoid LaunchedEffect/DisposableEffect/etc that can use the VM as a key
-            .filter { callExpression -> callExpression.calleeExpression?.text?.endsWith("Effect") == false }
+            .filter { callExpression -> callExpression.isRestartableEffect }
             .flatMap { callExpression ->
                 // Get VALUE_ARGUMENT that has a REFERENCE_EXPRESSION. This would map to `viewModel` in this example:
                 // MyComposable(viewModel, ...)

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelForwarding.kt
@@ -31,7 +31,7 @@ class ComposeViewModelForwarding : ComposeKtVisitor {
         bodyBlock.findDirectChildrenByClass<KtCallExpression>()
             .filter { callExpression -> callExpression.calleeExpression?.text?.first()?.isUpperCase() ?: false }
             // Avoid LaunchedEffect/DisposableEffect/etc that can use the VM as a key
-            .filter { callExpression -> callExpression.isRestartableEffect }
+            .filterNot { callExpression -> callExpression.isRestartableEffect }
             .flatMap { callExpression ->
                 // Get VALUE_ARGUMENT that has a REFERENCE_EXPRESSION. This would map to `viewModel` in this example:
                 // MyComposable(viewModel, ...)


### PR DESCRIPTION
In `ComposeViewModelForwarding` we were blank checking that `*Effect` was not used. In reality, the list of restartable effects is smaller and we could keep it up to date ourselves.