### PR TITLE
Add whetstone VM factory function to the list of VM factories

### DIFF
--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeViewModelInjection.kt
@@ -103,7 +103,14 @@ class ComposeViewModelInjection : ComposeKtVisitor {
 
     companion object {
 
-        val KnownViewModelFactories by lazy { setOf("viewModel", "weaverViewModel", "hiltViewModel") }
+        val KnownViewModelFactories by lazy {
+            setOf(
+                "viewModel", // AAC VM
+                "weaverViewModel", // Weaver
+                "hiltViewModel", // Hilt
+                "injectedViewModel" // Whetstone
+            )
+        }
 
         fun errorMessage(factoryName: String) = """
             Implicit dependencies of composables should be made explicit.


### PR DESCRIPTION
Looking at [Whetstone](https://github.com/deliveryhero/whetstone), they are using a method [injectedViewModel](https://github.com/deliveryhero/whetstone/blob/14077f8d8d8d0a446b855a270ba8be5d54d27f08/whetstone-compose/src/main/java/com/deliveryhero/whetstone/compose/ViewModel.kt) to acquire VMs. I am just adding it to the list of watched methods for VM forwarding/injecting rules.