### PR TITLE
Fix issue that prevents accessing right configuration data

### DIFF
--- a/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
+++ b/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
@@ -26,7 +26,7 @@ abstract class TwitterDetektRule(
     config: Config = Config.empty
 ) : Rule(config), ComposeKtVisitor {
 
-    private val config: ComposeKtConfig = DetektComposeKtConfig(config)
+    private val config: ComposeKtConfig by lazy { DetektComposeKtConfig(this) }
 
     private val emitter: Emitter = Emitter { element, message, canBeAutoCorrected ->
         // Grab the named element if there were any, otherwise fall back to the whole PsiElement


### PR DESCRIPTION
It seems that `config` param received by any `TwitterDetektRule` couldn't be used as it is. Instead, we should rely on reference to `Rule` as it also extends from `ConfigAware`