### PR TITLE
Add tests to ensure all rules are added to their rulesets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.22.0"
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 assertj = "org.assertj:assertj-core:3.23.1"
+reflections = "org.reflections:reflections:0.10.2"
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version = "6.11.0" }

--- a/rules/detekt/build.gradle
+++ b/rules/detekt/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     testImplementation libs.junit5
     testImplementation libs.junit5.params
     testImplementation libs.assertj
+    testImplementation libs.reflections
 }

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/TwitterComposeRuleSetProviderTest.kt
@@ -1,0 +1,23 @@
+// Copyright 2022 Twitter, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package com.twitter.compose.rules.detekt
+
+import com.twitter.rules.core.detekt.TwitterDetektRule
+import io.gitlab.arturbosch.detekt.api.Config
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.reflections.Reflections
+
+class TwitterComposeRuleSetProviderTest {
+
+    private val ruleSetProvider = TwitterComposeRuleSetProvider()
+    private val ruleSet = ruleSetProvider.instance(Config.empty)
+
+    @Test
+    fun `ensure all rules in the package are represented in the ruleset`() {
+        val reflections = Reflections(ruleSetProvider.javaClass.packageName)
+        val ruleClassesInPackage = reflections.getSubTypesOf(TwitterDetektRule::class.java)
+        val ruleClassesInRuleSet = ruleSet.rules.filterIsInstance<TwitterDetektRule>().map { it::class.java }.toSet()
+        assertThat(ruleClassesInRuleSet).containsExactlyInAnyOrderElementsOf(ruleClassesInPackage)
+    }
+}

--- a/rules/ktlint/build.gradle
+++ b/rules/ktlint/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     testImplementation libs.junit5
     testImplementation libs.junit5.params
     testImplementation libs.assertj
+    testImplementation libs.reflections
 }


### PR DESCRIPTION
There have been a couple of instances where a new rule wasn't added to its ruleset which caused it not to be active in specific versions of the library. With this change, we are able to proactively detect this (which is a very common occurence, it's so easy to forget this step!)