### PR TITLE
Add twitter_compose_ prefix to ktlint rules config entries

### DIFF
--- a/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
+++ b/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
@@ -8,7 +8,8 @@ import com.twitter.rules.core.util.toSnakeCase
 
 /**
  * Manages the configuration for ktlint rules. In ktlint, configs are typically in snake case, while in the
- * whole project and in detekt they are camel case, so this class will convert all camel case keys to snake case.
+ * whole project and in detekt they are camel case, so this class will convert all camel case keys to snake case,
+ * and add a "twitter_compose_" prefix to all of them.
  * Results will be memoized as well, as config shouldn't be changing during the lifetime of a rule.
  */
 internal class KtlintComposeKtConfig(
@@ -21,17 +22,19 @@ internal class KtlintComposeKtConfig(
         cache.getOrPut(key) { value() } as? T
 
     override fun getInt(key: String, default: Int): Int =
-        getValueAsOrPut(key) { properties[key.toSnakeCase()]?.getValueAs<String>()?.toInt() } ?: default
+        getValueAsOrPut(key) { properties[ktlintKey(key)]?.getValueAs<String>()?.toInt() } ?: default
 
     override fun getString(key: String, default: String?): String? =
-        getValueAsOrPut(key) { properties[key.toSnakeCase()]?.getValueAs() } ?: default
+        getValueAsOrPut(key) { properties[ktlintKey(key)]?.getValueAs() } ?: default
 
     override fun getList(key: String, default: List<String>): List<String> =
         getValueAsOrPut(key) {
-            val original = properties[key.toSnakeCase()]?.getValueAs<String>() ?: return@getValueAsOrPut default
+            val original = properties[ktlintKey(key)]?.getValueAs<String>() ?: return@getValueAsOrPut default
             original.split(',', ';').map { it.trim() }
         } ?: default
 
     override fun getSet(key: String, default: Set<String>): Set<String> =
         getValueAsOrPut(key) { getList(key, default.toList()).toSet() } ?: default
+
+    private fun ktlintKey(key: String): String = "twitter_compose_${key.toSnakeCase()}"
 }

--- a/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
+++ b/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.Test
 
 class KtlintComposeKtConfigTest {
     private val mapping = mutableMapOf<String, Property>().apply {
-        put("my_int", "10".prop)
-        put("my_string", "abcd".prop)
-        put("my_list", "a,b,c,a".prop)
-        put("my_list2", "a , b , c,a".prop)
-        put("my_set", "a,b,c,a,b,c".prop)
-        put("my_set2", "  a, b,c ,a  , b  ,  c ".prop)
+        put("twitter_compose_my_int", "10".prop)
+        put("twitter_compose_my_string", "abcd".prop)
+        put("twitter_compose_my_list", "a,b,c,a".prop)
+        put("twitter_compose_my_list2", "a , b , c,a".prop)
+        put("twitter_compose_my_set", "a,b,c,a,b,c".prop)
+        put("twitter_compose_my_set2", "  a, b,c ,a  , b  ,  c ".prop)
     }
 
     private val properties: EditorConfigProperties = mapping

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -45,7 +45,7 @@ There are some rules (`twitter-compose:content-emitter-returning-values-check` a
 
 ```editorconfig
 [*.{kt,kts}]
-content_emitters = MyComposable,MyOtherComposable
+twitter_compose_content_emitters = MyComposable,MyOtherComposable
 ```
 
 ### Providing a list of allowed `CompositionLocal`s
@@ -54,7 +54,7 @@ For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal
 
 ```editorconfig
 [*.{kt,kts}]
-allowed_composition_locals = LocalSomething,LocalSomethingElse
+twitter_compose_allowed_composition_locals = LocalSomething,LocalSomethingElse
 ```
 
 ## Disabling a specific rule

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
@@ -8,7 +8,7 @@ import org.ec4j.core.model.PropertyType
 val contentEmittersProperty: UsesEditorConfigProperties.EditorConfigProperty<String> =
     UsesEditorConfigProperties.EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
-            "content_emitters",
+            "twitter_compose_content_emitters",
             "A comma separated list of composable functions that emit content (e.g. UI)",
             PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet()
@@ -26,7 +26,7 @@ val contentEmittersProperty: UsesEditorConfigProperties.EditorConfigProperty<Str
 val compositionLocalAllowlistProperty: UsesEditorConfigProperties.EditorConfigProperty<String> =
     UsesEditorConfigProperties.EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
-            "allowed_composition_locals",
+            "twitter_compose_allowed_composition_locals",
             "A comma separated list of allowed CompositionLocals",
             PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet()


### PR DESCRIPTION
This patch changes how the rules are named in ktlint, to add a prefix to the rule (which is a common practice, as all config is bundled together which makes it hard to contextualize what it configures). Detekt configs are unchanged, as they are well scoped out of the box in its config files.