### PR TITLE
Add boolean support in ComposeKtConfig

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
@@ -11,6 +11,7 @@ interface ComposeKtConfig {
     fun getString(key: String, default: String?): String?
     fun getList(key: String, default: List<String>): List<String>
     fun getSet(key: String, default: Set<String>): Set<String>
+    fun getBoolean(key: String, default: Boolean): Boolean
 
     companion object {
         private val Key: Key<ComposeKtConfig> = Key("twitter_compose_rules_config")
@@ -19,6 +20,7 @@ interface ComposeKtConfig {
             override fun getString(key: String, default: String?): String? = default
             override fun getList(key: String, default: List<String>): List<String> = default
             override fun getSet(key: String, default: Set<String>) = default
+            override fun getBoolean(key: String, default: Boolean) = default
         }
 
         fun PsiElement.config(): ComposeKtConfig = containingFile.getUserData(Key) ?: ReturnDefaults

--- a/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfig.kt
+++ b/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfig.kt
@@ -36,4 +36,7 @@ internal class DetektComposeKtConfig(
 
     override fun getSet(key: String, default: Set<String>): Set<String> =
         valueOrPut(key) { getList(key, default.toList()).toSet() } ?: default
+
+    override fun getBoolean(key: String, default: Boolean): Boolean =
+        valueOrPut(key) { config.valueOrDefault(key, default) } ?: default
 }

--- a/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
+++ b/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
@@ -15,7 +15,9 @@ class DetektComposeKtConfigTest {
         put("myList2", "a , b , c,a")
         put("mySet", "a,b,c,a,b,c")
         put("mySet2", "  a, b,c ,a  , b  ,  c ")
+        put("myBool", true)
     }
+
     private val detektConfig = TestConfig(mapping)
     private val config = DetektComposeKtConfig(detektConfig)
 
@@ -44,6 +46,12 @@ class DetektComposeKtConfigTest {
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("myOtherSet", setOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `returns booleans from Config, and default values when unset`() {
+        assertThat(config.getBoolean("myBool", false)).isTrue()
+        assertThat(config.getBoolean("myOtherBool", false)).isFalse()
     }
 
     @Test

--- a/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
+++ b/core-detekt/src/test/kotlin/com/twitter/rules/core/detekt/DetektComposeKtConfigTest.kt
@@ -62,6 +62,7 @@ class DetektComposeKtConfigTest {
         assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getBoolean("myBool", false)).isTrue()
 
         mapping["myInt"] = 100
         mapping["myString"] = "XYZ"
@@ -69,6 +70,7 @@ class DetektComposeKtConfigTest {
         mapping["myList2"] = "z,y"
         mapping["mySet"] = "a"
         mapping["mySet2"] = "a, b"
+        mapping["myBool"] = false
 
         assertThat(config.getInt("myInt", 0)).isEqualTo(10)
         assertThat(config.getString("myString", null)).isEqualTo("abcd")
@@ -76,5 +78,6 @@ class DetektComposeKtConfigTest {
         assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getBoolean("myBool", false)).isTrue()
     }
 }

--- a/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
+++ b/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
@@ -36,5 +36,8 @@ internal class KtlintComposeKtConfig(
     override fun getSet(key: String, default: Set<String>): Set<String> =
         getValueAsOrPut(key) { getList(key, default.toList()).toSet() } ?: default
 
+    override fun getBoolean(key: String, default: Boolean): Boolean =
+        getValueAsOrPut(key) { properties[ktlintKey(key)]?.getValueAs<String>()?.toBooleanStrictOrNull() } ?: default
+
     private fun ktlintKey(key: String): String = "twitter_compose_${key.toSnakeCase()}"
 }

--- a/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
+++ b/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
@@ -15,6 +15,7 @@ class KtlintComposeKtConfigTest {
         put("twitter_compose_my_list2", "a , b , c,a".prop)
         put("twitter_compose_my_set", "a,b,c,a,b,c".prop)
         put("twitter_compose_my_set2", "  a, b,c ,a  , b  ,  c ".prop)
+        put("twitter_compose_my_bool", "true".prop)
     }
 
     private val properties: EditorConfigProperties = mapping
@@ -45,6 +46,12 @@ class KtlintComposeKtConfigTest {
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("myOtherSet", setOf("a"))).containsExactly("a")
+    }
+
+    @Test
+    fun `returns boolean from properties, and default values when unset`() {
+        assertThat(config.getBoolean("myBool", false)).isTrue()
+        assertThat(config.getBoolean("myOtherBool", false)).isFalse()
     }
 
     @Test

--- a/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
+++ b/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
@@ -62,6 +62,7 @@ class KtlintComposeKtConfigTest {
         assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getBoolean("myBool", false)).isTrue()
 
         mapping["my_int"] = "100".prop
         mapping["my_string"] = "XYZ".prop
@@ -69,6 +70,7 @@ class KtlintComposeKtConfigTest {
         mapping["my_list2"] = "z,y".prop
         mapping["my_set"] = "a".prop
         mapping["my_set2"] = "a, b".prop
+        mapping["my_bool"] = "false".prop
 
         assertThat(config.getInt("myInt", 0)).isEqualTo(10)
         assertThat(config.getString("myString", null)).isEqualTo("abcd")
@@ -76,6 +78,7 @@ class KtlintComposeKtConfigTest {
         assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
         assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
         assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
+        assertThat(config.getBoolean("myBool", false)).isTrue()
     }
 
     private val String.prop: Property


### PR DESCRIPTION
For an upcoming rule update, we need to support boolean properties in the config.