### PR TITLE
Add an option to configure ComposePreviewPublic to flag all previews

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/ComposeKtConfig.kt
@@ -27,8 +27,11 @@ interface ComposeKtConfig {
 
         fun ASTNode.config(): ComposeKtConfig = psi.config()
 
+        private val PsiElement.hasConfigAttached: Boolean
+            get() = containingFile.getUserData(Key) != null
+
         fun PsiElement.attach(config: ComposeKtConfig) {
-            containingFile.putUserData(Key, config)
+            if (!hasConfigAttached) containingFile.putUserData(Key, config)
         }
     }
 }

--- a/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
+++ b/core-detekt/src/main/kotlin/com/twitter/rules/core/detekt/TwitterDetektRule.kt
@@ -58,11 +58,13 @@ abstract class TwitterDetektRule(
 
     override fun visitClass(klass: KtClass) {
         super<Rule>.visitClass(klass)
+        klass.attach(config)
         visitClass(klass, autoCorrect, emitter)
     }
 
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
+        element.attach(config)
         when (element.node.elementType) {
             KtStubElementTypes.FUNCTION -> {
                 val function = element.cast<KtFunction>()

--- a/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
+++ b/core-ktlint/src/main/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfig.kt
@@ -37,7 +37,7 @@ internal class KtlintComposeKtConfig(
         getValueAsOrPut(key) { getList(key, default.toList()).toSet() } ?: default
 
     override fun getBoolean(key: String, default: Boolean): Boolean =
-        getValueAsOrPut(key) { properties[ktlintKey(key)]?.getValueAs<String>()?.toBooleanStrictOrNull() } ?: default
+        getValueAsOrPut(key) { properties[ktlintKey(key)]?.getValueAs<Boolean>() } ?: default
 
     private fun ktlintKey(key: String): String = "twitter_compose_${key.toSnakeCase()}"
 }

--- a/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
+++ b/core-ktlint/src/test/kotlin/com/twitter/rules/core/ktlint/KtlintComposeKtConfigTest.kt
@@ -5,6 +5,9 @@ package com.twitter.rules.core.ktlint
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
+import org.ec4j.core.model.PropertyType.LowerCasingPropertyType
+import org.ec4j.core.model.PropertyType.PropertyValueParser.BOOLEAN_VALUE_PARSER
 import org.junit.jupiter.api.Test
 
 class KtlintComposeKtConfigTest {
@@ -15,7 +18,7 @@ class KtlintComposeKtConfigTest {
         put("twitter_compose_my_list2", "a , b , c,a".prop)
         put("twitter_compose_my_set", "a,b,c,a,b,c".prop)
         put("twitter_compose_my_set2", "  a, b,c ,a  , b  ,  c ".prop)
-        put("twitter_compose_my_bool", "true".prop)
+        put("twitter_compose_my_bool", true.prop)
     }
 
     private val properties: EditorConfigProperties = mapping
@@ -70,7 +73,7 @@ class KtlintComposeKtConfigTest {
         mapping["my_list2"] = "z,y".prop
         mapping["my_set"] = "a".prop
         mapping["my_set2"] = "a, b".prop
-        mapping["my_bool"] = "false".prop
+        mapping["my_bool"] = false.prop
 
         assertThat(config.getInt("myInt", 0)).isEqualTo(10)
         assertThat(config.getString("myString", null)).isEqualTo("abcd")
@@ -83,4 +86,15 @@ class KtlintComposeKtConfigTest {
 
     private val String.prop: Property
         get() = Property.builder().value(this).build()
+
+    private val Boolean.prop: Property
+        get() = Property.builder()
+            .type(LowerCasingPropertyType("", "", BOOLEAN_VALUE_PARSER, "true", "false"))
+            .value(
+                when (this) {
+                    true -> PropertyType.PropertyValue.valid("true", true)
+                    false -> PropertyType.PropertyValue.valid("false", false)
+                }
+            )
+            .build()
 }

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -52,6 +52,8 @@ TwitterCompose:
     active: true
   PreviewPublic:
     active: true
+    # You can optionally disable that only previews with @PreviewParameter are flagged
+    # previewPublicOnlyIfParams: false
   RememberMissing:
     active: true
   UnstableCollections:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -57,6 +57,15 @@ For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal
 twitter_compose_allowed_composition_locals = LocalSomething,LocalSomethingElse
 ```
 
+### Make it so that all @Preview composables must be not public, no exceptions
+
+In `preview-public-check`, only previews with a `@PreviewParameter` are required to be non-public by default. However, if you want to make it so ALL `@Preview` composables are non-public, you can add this to your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+twitter_compose_preview_public_only_if_params = false
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposePreviewPublic.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposePreviewPublic.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.compose.rules
 
+import com.twitter.rules.core.ComposeKtConfig.Companion.config
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.util.isPreview
@@ -17,8 +18,12 @@ class ComposePreviewPublic : ComposeKtVisitor {
         if (!function.isPreview) return
         // We only care about public methods
         if (!function.isPublic) return
+
         // If the method is public, none of it's params should be tagged as preview
-        if (function.valueParameters.none { it.isPreviewParameter }) return
+        // This is configurable by the `previewPublicOnlyIfParams` config value
+        if (function.config().getBoolean("previewPublicOnlyIfParams", true)) {
+            if (function.valueParameters.none { it.isPreviewParameter }) return
+        }
 
         // If we got here, it's a public method in a @Preview composable with a @PreviewParameter parameter
         emitter.report(function, ComposablesPreviewShouldNotBePublic, true)

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
@@ -4,6 +4,7 @@ package com.twitter.rules.core.ktlint
 
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import org.ec4j.core.model.PropertyType
+import org.ec4j.core.model.PropertyType.PropertyValueParser
 
 val contentEmittersProperty: UsesEditorConfigProperties.EditorConfigProperty<String> =
     UsesEditorConfigProperties.EditorConfigProperty(
@@ -39,4 +40,17 @@ val compositionLocalAllowlistProperty: UsesEditorConfigProperties.EditorConfigPr
                 else -> property?.getValueAs()
             }
         }
+    )
+
+val previewPublicOnlyIfParams: UsesEditorConfigProperties.EditorConfigProperty<Boolean> =
+    UsesEditorConfigProperties.EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "twitter_compose_preview_public_only_if_params",
+            "If set to true, it means ",
+            //
+            PropertyValueParser.BOOLEAN_VALUE_PARSER,
+            "true",
+            "false"
+        ),
+        defaultValue = true
     )

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules.ktlint
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.twitter.compose.rules.ComposePreviewPublic
+import com.twitter.rules.core.ktlint.previewPublicOnlyIfParams
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
@@ -64,6 +65,34 @@ class ComposePreviewPublicCheckTest {
                 detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic
             )
         )
+    }
+
+    @Test
+    fun `errors when a public preview composable is used when previewPublicOnlyIfParams is false`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun MyComposable() { }
+            @CombinedPreviews
+            @Composable
+            fun MyComposable() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(previewPublicOnlyIfParams to false)
+            .hasLintViolations(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 5,
+                    detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic
+                )
+            )
     }
 
     @Test


### PR DESCRIPTION
By default, `ComposePreviewPublic` will only flag public previews if they use a `@PreviewParameter`, because we know for sure that they are only going to be used for previews. This will continue to be the default behavior, but if people want to flag ALL public previews, they can use `previewPublicOnlyIfParams` to do that now.

Closes #95.