### PR TITLE
Add default configuration for detekt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,3 +38,6 @@ ij_groovy_for_brace_force = always
 
 [{*.ant,*.fxml,*.jhm,*.jnlp,*.jrxml,*.rng,*.tld,*.wsdl,*.xml,*.xsd,*.xsl,*.xslt,*.xul}]
 ij_continuation_indent_size = 4
+
+[{*.yml}]
+ij_continuation_indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ google-services.json
 # Banish DS_Store files 
 .DS_Store
 
-# MkDocs ste
+# MkDocs site
 site/
+
+# Fleet
+**/.fleet/settings.json

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -1,0 +1,35 @@
+TwitterCompose:
+  CompositionLocalAllowlist:
+    active: true
+  CompositionLocalNaming:
+    active: true
+  ContentEmitterReturningValues:
+    active: true
+  ModifierComposable:
+    active: true
+  ModifierMissing:
+    active: true
+  ModifierReused:
+    active: true
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+  MutableParams:
+    active: true
+  ComposableNaming:
+    active: true
+  ComposableParamOrder:
+    active: true
+  PreviewNaming:
+    active: true
+  PreviewPublic:
+    active: true
+  RememberMissing:
+    active: true
+  UnstableCollections:
+    active: true
+  ViewModelForwarding:
+    active: true
+  ViewModelInjection:
+    active: true


### PR DESCRIPTION
We provide a default config for Detekt so it's not as picky with where the TwitterCompose configuration is provided. 