### PR TITLE
Introduce `allowedNames` config for `ComposeNaming` check

### DIFF
--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -66,6 +66,15 @@ In `preview-public-check`, only previews with a `@PreviewParameter` are required
 twitter_compose_preview_public_only_if_params = false
 ```
 
+### Allowing matching function names
+
+The `twitter-compose:naming-check` rule requires all composables that return a value to be lowercased. If you want to allow certain patterns though, you can configure a comma-separated list of matching regexes in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+twitter_compose_allowed_composable_function_names = .*Presenter,.*SomethingElse
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `twitter-compose` tag.

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
@@ -24,7 +24,7 @@ class ComposeNaming : ComposeKtVisitor {
                 // If it's allowed, we don't report it
                 val isAllowed = function.config().getSet("allowedNames", emptySet())
                     .any {
-                        it.toRegex().matches(function.name ?: "")
+                        it.toRegex().matches(functionName)
                     }
                 if (isAllowed) return
                 emitter.report(function, ComposablesThatReturnResultsShouldBeLowercase)

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
@@ -22,7 +22,7 @@ class ComposeNaming : ComposeKtVisitor {
             // If it returns value, the composable should start with a lowercase letter
             if (firstLetter.isUpperCase()) {
                 // If it's allowed, we don't report it
-                val isAllowed = function.config().getSet("allowedNames", emptySet())
+                val isAllowed = function.config().getSet("allowedComposableFunctionNames", emptySet())
                     .any {
                         it.toRegex().matches(functionName)
                     }

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeNaming.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.twitter.compose.rules
 
+import com.twitter.rules.core.ComposeKtConfig.Companion.config
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.report
@@ -14,11 +15,18 @@ class ComposeNaming : ComposeKtVisitor {
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
         // If it's a block we can't know if there is a return type or not from ktlint
         if (!function.hasBlockBody()) return
-        val firstLetter = function.name?.first() ?: return
+        val functionName = function.name?.takeUnless(String::isEmpty) ?: return
+        val firstLetter = functionName.first()
 
         if (function.returnsValue) {
             // If it returns value, the composable should start with a lowercase letter
             if (firstLetter.isUpperCase()) {
+                // If it's allowed, we don't report it
+                val isAllowed = function.config().getSet("allowedNames", emptySet())
+                    .any {
+                        it.toRegex().matches(function.name ?: "")
+                    }
+                if (isAllowed) return
                 emitter.report(function, ComposablesThatReturnResultsShouldBeLowercase)
             }
         } else {

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 class ComposeNamingCheckTest {
 
     private val testConfig = TestConfig(
-        "allowedNames" to listOf(".*Presenter")
+        "allowedComposableFunctionNames" to listOf(".*Presenter")
     )
     private val rule = ComposeNamingCheck(testConfig)
 

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeNamingCheckTest.kt
@@ -3,8 +3,8 @@
 package com.twitter.compose.rules.detekt
 
 import com.twitter.compose.rules.ComposeNaming
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
@@ -12,7 +12,10 @@ import org.junit.jupiter.api.Test
 
 class ComposeNamingCheckTest {
 
-    private val rule = ComposeNamingCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "allowedNames" to listOf(".*Presenter")
+    )
+    private val rule = ComposeNamingCheck(testConfig)
 
     @Test
     fun `passes when a composable that returns values is lowercase`() {
@@ -21,6 +24,17 @@ class ComposeNamingCheckTest {
             """
                 @Composable
                 fun myComposable(): Something { }
+            """.trimIndent()
+        assertThat(rule.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `passes when a composable that returns values is uppercase but allowed`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun ProfilePresenter(): Something { }
             """.trimIndent()
         assertThat(rule.lint(code)).isEmpty()
     }

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
@@ -59,7 +59,7 @@ val allowedComposeNamingNames: UsesEditorConfigProperties.EditorConfigProperty<S
     UsesEditorConfigProperties.EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
             "twitter_compose_allowed_composable_function_names",
-            "A comma separated list of regexes of allowed composable fuinction names",
+            "A comma separated list of regexes of allowed composable function names",
             PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet()
         ),

--- a/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/com/twitter/compose/rules/ktlint/EditorConfigProperties.kt
@@ -54,3 +54,21 @@ val previewPublicOnlyIfParams: UsesEditorConfigProperties.EditorConfigProperty<B
         ),
         defaultValue = true
     )
+
+val allowedComposeNamingNames: UsesEditorConfigProperties.EditorConfigProperty<String> =
+    UsesEditorConfigProperties.EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "twitter_compose_allowed_composable_function_names",
+            "A comma separated list of regexes of allowed composable fuinction names",
+            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet()
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        }
+    )

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeNamingCheckTest.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules.ktlint
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
 import com.twitter.compose.rules.ComposeNaming
+import com.twitter.rules.core.ktlint.allowedComposeNamingNames
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
@@ -21,6 +22,21 @@ class ComposeNamingCheckTest {
                 fun myComposable(): Something { }
             """.trimIndent()
         namingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when a composable that returns values is uppercase but allowed`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun ProfilePresenter(): Something { }
+            """.trimIndent()
+        namingRuleAssertThat(code)
+            .withEditorConfigOverride(
+                allowedComposeNamingNames to ".*Presenter"
+            )
+            .hasNoLintViolations()
     }
 
     @Test


### PR DESCRIPTION
Wasn't sure what to call the editorconfig property, let me know!

Resolves #104