### PR TITLE
Fix `ComposeModifierReused` when using nested KtDotQualifiedExpressions

### DIFF
--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierReusedCheckTest.kt
@@ -47,10 +47,23 @@ class ComposeModifierReusedCheckTest {
                         SomethingElse(myMod)
                     }
                 }
+                @Composable
+                fun FoundThisOneInTheWild(modifier: Modifier = Modifier) {
+                    Box(
+                        modifier = modifier
+                            .size(AvatarSize.Default.size)
+                            .clip(CircleShape)
+                            .then(colorModifier)
+                    ) {
+                        Box(
+                            modifier = modifier.padding(spacesBorderWidth)
+                        )
+                    }
+                }
             """.trimIndent()
 
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(9)
+        assertThat(errors)
             .hasSourceLocations(
                 SourceLocation(3, 5),
                 SourceLocation(4, 9),
@@ -60,7 +73,9 @@ class ComposeModifierReusedCheckTest {
                 SourceLocation(19, 5),
                 SourceLocation(20, 5),
                 SourceLocation(25, 9),
-                SourceLocation(26, 9)
+                SourceLocation(26, 9),
+                SourceLocation(31, 5),
+                SourceLocation(37, 9)
             )
         for (error in errors) {
             assertThat(error).hasMessage(ComposeModifierReused.ModifierShouldBeUsedOnceOnly)

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierReusedCheckTest.kt
@@ -45,6 +45,19 @@ class ComposeModifierReusedCheckTest {
                         SomethingElse(myMod)
                     }
                 }
+                @Composable
+                fun FoundThisOneInTheWild(modifier: Modifier = Modifier) {
+                    Box(
+                        modifier = modifier
+                            .size(AvatarSize.Default.size)
+                            .clip(CircleShape)
+                            .then(colorModifier)
+                    ) {
+                        Box(
+                            modifier = modifier.padding(spacesBorderWidth)
+                        )
+                    }
+                }
             """.trimIndent()
 
         modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
@@ -90,6 +103,16 @@ class ComposeModifierReusedCheckTest {
             ),
             LintViolation(
                 line = 26,
+                col = 9,
+                detail = ComposeModifierReused.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 31,
+                col = 5,
+                detail = ComposeModifierReused.ModifierShouldBeUsedOnceOnly
+            ),
+            LintViolation(
+                line = 37,
                 col = 9,
                 detail = ComposeModifierReused.ModifierShouldBeUsedOnceOnly
             )


### PR DESCRIPTION
`ComposeModifierReused` was ignoring legit violations when reusing modifiers that had deeply nested values, because the `KtDotQualifiedExpression` handling was not traversing the chained methods to get to the KtReferenceExpression leaf.