### PR TITLE
Do not fail for default Modifier in abstract functions

### DIFF
--- a/core-common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
+++ b/core-common/src/main/kotlin/com/twitter/rules/core/util/KtFunctions.kt
@@ -32,5 +32,8 @@ val KtFunction.isActual: Boolean
 val KtFunction.isExpect: Boolean
     get() = hasModifier(KtTokens.EXPECT_KEYWORD)
 
+val KtFunction.isAbstract: Boolean
+    get() = hasModifier(KtTokens.ABSTRACT_KEYWORD)
+
 val KtFunction.definedInInterface: Boolean
     get() = ((parent as? KtClassBody)?.parent as? KtClass)?.isInterface() ?: false

--- a/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierWithoutDefault.kt
+++ b/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeModifierWithoutDefault.kt
@@ -5,6 +5,7 @@ package com.twitter.compose.rules
 import com.twitter.rules.core.ComposeKtVisitor
 import com.twitter.rules.core.Emitter
 import com.twitter.rules.core.util.definedInInterface
+import com.twitter.rules.core.util.isAbstract
 import com.twitter.rules.core.util.isActual
 import com.twitter.rules.core.util.isModifier
 import com.twitter.rules.core.util.isOverride
@@ -15,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 class ComposeModifierWithoutDefault : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
-        if (function.definedInInterface || function.isActual || function.isOverride) return
+        if (function.definedInInterface || function.isActual || function.isOverride || function.isAbstract) return
 
         // Look for modifier params in the composable signature, and if any without a default value is found, error out.
         function.valueParameters.filter { it.isModifier }

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeModifierWithoutDefaultCheckTest.kt
@@ -54,6 +54,20 @@ class ComposeModifierWithoutDefaultCheckTest {
     }
 
     @Test
+    fun `passes when a Composable is an abstract function but without default values`() {
+        @Language("kotlin")
+        val composableCode = """
+                abstract class Bleh {
+                    @Composable
+                    abstract fun Something(modifier: Modifier)
+                }
+        """.trimIndent()
+
+        val errors = rule.lint(composableCode)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes when a Composable has modifiers with defaults`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/com/twitter/compose/rules/ktlint/ComposeModifierWithoutDefaultCheckTest.kt
@@ -65,6 +65,19 @@ class ComposeModifierWithoutDefaultCheckTest {
     }
 
     @Test
+    fun `passes when a Composable is an abstract function but without default values`() {
+        @Language("kotlin")
+        val composableCode = """
+                abstract class Bleh {
+                    @Composable
+                    abstract fun Something(modifier: Modifier)
+                }
+        """.trimIndent()
+
+        modifierRuleAssertThat(composableCode).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when a Composable has modifiers with defaults`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Similar to #86 abstract functions don't have default parameters