### PR TITLE
Add exclude field to MultipleEmitters rule.

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -42,6 +42,7 @@ TwitterCompose:
     active: true
       # You can optionally add your own composables here
       # contentEmitters: MyComposable,MyOtherComposable
+      # exclude: MyComposable,MyOtherComposable
   MutableParams:
     active: true
   ComposableNaming:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -133,7 +133,7 @@ This effectively ties the function to be called from a Column, but is still not 
 
 Related rule: [twitter-compose:multiple-emitters-check](https://github.com/twitter/compose-rules/blob/main/rules/common/src/main/kotlin/com/twitter/compose/rules/ComposeMultipleContentEmitters.kt)
 
-> **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
+> **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint. To exclude your composables from the rule add them to the `exclude` field in your Detekt config.
 
 ### Naming CompositionLocals properly
 

--- a/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/com/twitter/compose/rules/detekt/ComposeMultipleContentEmittersCheckTest.kt
@@ -14,6 +14,7 @@ class ComposeMultipleContentEmittersCheckTest {
 
     private val testConfig = TestConfig(
         "contentEmitters" to listOf("Potato", "Banana"),
+        "exclude" to listOf("ExcludedComposable"),
     )
     private val rule = ComposeMultipleContentEmittersCheck(testConfig)
 
@@ -142,6 +143,33 @@ class ComposeMultipleContentEmittersCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).hasSize(1)
             .hasStartSourceLocation(2, 5)
+        assertThat(errors.first()).hasMessage(ComposeMultipleContentEmitters.MultipleContentEmittersDetected)
+    }
+
+    @Test
+    fun `make_sure_that_excluded_composables_are_not_checked`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun ExcludedComposable() {
+                    Text("Hi")
+                    Text("Hola")
+                    Something2()
+                }
+                @Composable
+                fun Something2() {
+                    Text("Alo")
+                    Text("Hola")
+                }
+                @Composable
+                fun Something3() {
+                    Text("Alo")
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasSize(1)
+            .hasStartSourceLocation(8, 5)
         assertThat(errors.first()).hasMessage(ComposeMultipleContentEmitters.MultipleContentEmittersDetected)
     }
 }


### PR DESCRIPTION
Hi! Please consider the possibility of adding a field exclude to the MultipleEmitter rule.
I ran into a situation when I have composable function which is always called inside Column, but it is not ColumnScope extension. Like this:

```
abstract class Screen {
  @Composable
  internal fun Content() {
    // Some logic
    Column(...) {
      Ui()
    }
  }

  @Composable
  abscract fun Ui()
}
```
I would not like to change it to `ColumnScope.Ui()` and fix it throughout the project.
It would be nice to just exclude `Ui` method from rule checking.
Maybe there are some other cases. Anyway it seems pretty flexible.

What do you think about it?